### PR TITLE
[feat] 플레이리스트 상세페이지 기능 구현

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['i.ibb.co'],
+    domains: ['i.ibb.co', 'dreamvault-s3.s3.ap-northeast-2.amazonaws.com'],
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.14",
     "@react-navigation/native": "^6.1.17",
+    "@sweetalert2/theme-dark": "^5.0.16",
     "@tanstack/react-query": "^5.29.0",
     "@types/react-router-dom": "^5.3.3",
     "axios": "^1.6.8",

--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -216,7 +216,7 @@ export async function fetchPlaylistDetail(
     const accessToken = await getCookie('accessToken');
     if (playlistId === 'like') {
       const response = await axios.get(
-        `${process.env.NEXT_PUBLIC_API_URL}/users/liked/tracks`,
+        `${process.env.NEXT_PUBLIC_API_URL}/users/liked/tracks?page=${pageIndex}&size=${size}`,
         {
           headers: {
             'Content-Type': 'application/json',
@@ -239,6 +239,32 @@ export async function fetchPlaylistDetail(
     }
   } catch (error) {
     console.error('API Fetch Error (playlist detail):', error);
+    throw error;
+  }
+}
+
+// 플레이리스트 수정
+export async function patchPlaylistName(
+  playlistId: string,
+  playlistName: string,
+) {
+  try {
+    const accessToken = await getCookie('accessToken');
+    const response = await axios.patch(
+      `${process.env.NEXT_PUBLIC_API_URL}/playlists/${playlistId}`,
+      {
+        playlist_name: playlistName,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('API Fetch Error (patch playlist name):', error);
     throw error;
   }
 }

--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -6,28 +6,6 @@
 import axios from 'axios';
 import { getCookie } from '@/app/Cookies';
 
-// 특정 플레이리스트 정보 가져오기
-export async function getPlaylist() {
-  try {
-    const response = await axios.get('/api/v1/playlists/playlist_id');
-    return response.data;
-  } catch (error) {
-    console.error('오류 발생:', error);
-    throw error;
-  }
-}
-
-// 모든 플레이리스트 정보 가져오기
-export async function getMyPlaylists() {
-  try {
-    const response = await axios.get('/api/v1/users/playlists/list');
-    return response.data;
-  } catch (error) {
-    console.error('오류 발생:', error);
-    throw error;
-  }
-}
-
 // 플레이리스트 생성
 export async function fetchTags(pageIndex: number) {
   try {
@@ -370,6 +348,30 @@ export async function deleteTrack(playlistId: string, trackId: string) {
     return response.data;
   } catch (error) {
     console.error('API Fetch Error (delete music from playlist):', error);
+    throw error;
+  }
+}
+
+// 특정 장르의 모든 곡 가져오기
+export async function fetchGenreDetail(
+  genreId: string,
+  pageIndex: number,
+  size: number,
+) {
+  try {
+    const accessToken = await getCookie('accessToken');
+    const response = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_URL}/genres/${genreId}/tracks?page=${pageIndex}&size=${size}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('API Fetch Error (genre detail):', error);
     throw error;
   }
 }

--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -243,6 +243,30 @@ export async function fetchPlaylistDetail(
   }
 }
 
+// 태그 상세정보 가져오기
+export async function fetchTagDetail(
+  tagId: string,
+  pageIndex: number,
+  size: number,
+) {
+  try {
+    const accessToken = await getCookie('accessToken');
+    const response = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_URL}/tags/${tagId}/tracks?page=${pageIndex}&size=${size}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('API Fetch Error (tag detail):', error);
+    throw error;
+  }
+}
+
 // 플레이리스트 수정
 export async function patchPlaylistName(
   playlistId: string,

--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -80,7 +80,7 @@ export async function fetchFollowPlaylistData() {
   const accessToken = await getCookie('accessToken');
   try {
     const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_URL}/playlists/users/followed?page=0&size=60`, // 하드코딩 수정 필요
+      `${process.env.NEXT_PUBLIC_API_URL}/playlists/users/followed?type=user_created&page=0&size=60`, // 하드코딩 수정 필요
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -268,3 +268,23 @@ export async function patchPlaylistName(
     throw error;
   }
 }
+
+// 플레이리스트 삭제
+export async function deletePlaylist(playlistId: string) {
+  try {
+    const accessToken = await getCookie('accessToken');
+    const response = await axios.delete(
+      `${process.env.NEXT_PUBLIC_API_URL}/playlists/${playlistId}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('API Fetch Error (delete playlist):', error);
+    throw error;
+  }
+}

--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -288,3 +288,64 @@ export async function deletePlaylist(playlistId: string) {
     throw error;
   }
 }
+
+// 플레이리스트 팔로우
+export async function postFollow(playlistId: string) {
+  try {
+    const accessToken = await getCookie('accessToken');
+    const response = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_URL}/playlists/${playlistId}/follow`,
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('API Fetch Error (follow playlist):', error);
+    throw error;
+  }
+}
+
+// 플레이리스트 언팔로우
+export async function deleteFollow(playlistId: string) {
+  try {
+    const accessToken = await getCookie('accessToken');
+    const response = await axios.delete(
+      `${process.env.NEXT_PUBLIC_API_URL}/playlists/${playlistId}/follow`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('API Fetch Error (unfollow playlist):', error);
+    throw error;
+  }
+}
+
+// 나의 플레이리스트에서 음악 삭제
+export async function deleteTrack(playlistId: string, trackId: string) {
+  try {
+    const accessToken = await getCookie('accessToken');
+    const response = await axios.delete(
+      `${process.env.NEXT_PUBLIC_API_URL}/playlists/${playlistId}/tracks/${trackId}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('API Fetch Error (delete music from playlist):', error);
+    throw error;
+  }
+}

--- a/src/app/components/AlbumCover/AlbumCoverSystem.tsx
+++ b/src/app/components/AlbumCover/AlbumCoverSystem.tsx
@@ -4,7 +4,12 @@ import React, { useState, useEffect } from 'react';
 import { albumCoverSystemProps } from '@/types/albumCover.ts';
 import Link from 'next/link';
 
-function AlbumCoverSystem({ image, title, Id }: albumCoverSystemProps) {
+function AlbumCoverSystem({
+  image,
+  title,
+  Id,
+  curation,
+}: albumCoverSystemProps) {
   const [albumRandomColor, setAlbumRandomColor] = useState('');
 
   useEffect(() => {
@@ -26,8 +31,8 @@ function AlbumCoverSystem({ image, title, Id }: albumCoverSystemProps) {
   return (
     <>
       <Link
-        href={`/playlist/${Id}`}
-        className="flex flex-col m-4 p-4 w-56 h-72 items-center justify-center hover-bg-opacity cursor-pointer"
+        href={`/${curation === 'tag' ? 'tag' : 'playlist'}/${Id}`}
+        className="hover-bg-opacity m-4 flex h-72 w-56 cursor-pointer flex-col items-center justify-center p-4"
       >
         {/* <Image
         src={image}
@@ -36,18 +41,18 @@ function AlbumCoverSystem({ image, title, Id }: albumCoverSystemProps) {
         width={192}
         height={192}
       /> */}
-        <img src={image} alt="Album cover" className="w-48 h-48 rounded-lg" />
+        <img src={image} alt="Album cover" className="h-48 w-48 rounded-lg" />
         <div
-          className={`h-48 w-48 rounded-lg z-10 -mt-48 ${albumRandomColor} opacity-50`}
+          className={`z-10 -mt-48 h-48 w-48 rounded-lg ${albumRandomColor} opacity-50`}
         />
         <p
           className={
-            'flex flex-wrap text-xl w-48 h-48 justify-center items-center z-20 font-bold drop-shadow-text p-4 -mt-48'
+            'drop-shadow-text z-20 -mt-48 flex h-48 w-48 flex-wrap items-center justify-center p-4 text-xl font-bold'
           }
         >
           {title}
         </p>
-        <p className="flex w-48 h-16 justify-center items-start text-white text-xl z-20 pt-4">
+        <p className="z-20 flex h-16 w-48 items-start justify-center pt-4 text-xl text-white">
           {title}
         </p>
       </Link>

--- a/src/app/genre/[genreId]/MusicElement.tsx
+++ b/src/app/genre/[genreId]/MusicElement.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+/* eslint-disable @next/next/no-img-element */
+/* eslint-disable object-curly-newline */
+/* eslint-disable operator-linebreak */
+
+import { MusicElementProps } from '@/types/playlist.ts';
+import numeral from 'numeral';
+import { IconButton, ThemeProvider } from '@mui/material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import { likes, disLikes } from '@/api/music.ts';
+import { useState } from 'react';
+import Link from 'next/link';
+import theme from '../../styles/theme.ts';
+
+export default function MusicElement({
+  image,
+  title,
+  like,
+  isLiked,
+  trackId,
+}: MusicElementProps) {
+  const [isLikedStore, setIsLikedStore] = useState(isLiked);
+  const [likeStore, setLikeStore] = useState(like);
+  const [formattedLike, setFormattedLike] = useState(
+    likeStore > 999
+      ? numeral(likeStore).format('0.0a')
+      : numeral(likeStore).format('0a'),
+  );
+
+  const handleLike = async () => {
+    if (isLikedStore) {
+      setIsLikedStore(false);
+      setLikeStore(likeStore - 1);
+      setFormattedLike(
+        likeStore > 999
+          ? numeral(likeStore - 1).format('0.0a')
+          : numeral(likeStore - 1).format('0a'),
+      );
+      disLikes(trackId).catch(() => {
+        // API 호출이 실패하면 상태를 되돌립니다
+        setIsLikedStore(true);
+        setLikeStore(likeStore);
+        setFormattedLike(
+          likeStore > 999
+            ? numeral(likeStore).format('0.0a')
+            : numeral(likeStore).format('0a'),
+        );
+      });
+    } else {
+      setIsLikedStore(true);
+      setLikeStore(likeStore + 1);
+      setFormattedLike(
+        likeStore > 999
+          ? numeral(likeStore + 1).format('0.0a')
+          : numeral(likeStore + 1).format('0a'),
+      );
+      likes(trackId).catch(() => {
+        // API 호출이 실패하면 상태를 되돌립니다
+        setIsLikedStore(false);
+        setLikeStore(likeStore);
+        setFormattedLike(
+          likeStore > 999
+            ? numeral(likeStore).format('0.0a')
+            : numeral(likeStore).format('0a'),
+        );
+      });
+    }
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div
+        className={
+          'hover-bg-opacity flex w-full flex-row items-center justify-start py-4'
+        }
+      >
+        <Link
+          href={`/track/${trackId}`}
+          className={'flex w-full flex-row items-center'}
+        >
+          <img
+            src={image}
+            alt="Album cover"
+            className="ml-10 h-24 w-24 rounded-lg"
+          />
+          <p className="mx-6 flex text-2xl">{title}</p>
+        </Link>
+
+        <div className="flex w-2/12 items-center justify-center text-2xl">
+          <IconButton onClick={handleLike}>
+            {isLikedStore ? (
+              <FavoriteIcon color="primary" fontSize="inherit" />
+            ) : (
+              <FavoriteBorderIcon color="primary" />
+            )}
+          </IconButton>
+
+          {formattedLike}
+        </div>
+        <div className="flex w-24 items-center justify-center">
+          <IconButton>
+            <PlayArrowIcon color="primary" fontSize="large" />
+          </IconButton>
+        </div>
+      </div>
+    </ThemeProvider>
+  );
+}

--- a/src/app/genre/[genreId]/PlayButton.tsx
+++ b/src/app/genre/[genreId]/PlayButton.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable no-unused-vars */
+
+'use client';
+
+import { IconButton, ThemeProvider } from '@mui/material';
+import PlayCircleIcon from '@mui/icons-material/PlayCircle';
+import theme from '../../styles/theme.ts';
+
+function PlayButton(playlistId: any) {
+  return (
+    <ThemeProvider theme={theme}>
+      <IconButton className="mx-8">
+        <PlayCircleIcon color="primary" style={{ fontSize: 60, opacity: 1 }} />
+      </IconButton>
+    </ThemeProvider>
+  );
+}
+
+export default PlayButton;

--- a/src/app/genre/[genreId]/page.tsx
+++ b/src/app/genre/[genreId]/page.tsx
@@ -11,19 +11,20 @@
 
 'use client';
 
-import { fetchTagDetail } from '@/api/playlist.ts';
+import { fetchGenreDetail } from '@/api/playlist.ts';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import PlayButton from './PlayButton.tsx';
 import MusicElement from './MusicElement.tsx';
 
-function page(props: { params: { tagId: string } }) {
-  const tagId = decodeURIComponent(props.params.tagId);
+function page(props: { params: { genreId: string } }) {
+  const genreId = decodeURIComponent(props.params.genreId);
   const renderSize = 12;
   const [playlistName, setPlaylistName] = useState('');
   const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteQuery({
-    queryKey: ['Tag Details', tagId],
-    queryFn: ({ pageParam }) => fetchTagDetail(tagId, pageParam, renderSize),
+    queryKey: ['Genre Details', genreId],
+    queryFn: ({ pageParam }) =>
+      fetchGenreDetail(genreId, pageParam, renderSize),
     initialPageParam: 0,
 
     getNextPageParam: (lastPage, allPages) => {
@@ -58,7 +59,7 @@ function page(props: { params: { tagId: string } }) {
 
   useEffect(() => {
     if (data === undefined) return;
-    setPlaylistName(data.pages['0'].tag_name);
+    setPlaylistName(data.pages['0'].genre_name);
   }, [data]);
 
   if (isLoading || data === undefined) return <div>Loading...</div>;
@@ -69,11 +70,11 @@ function page(props: { params: { tagId: string } }) {
         <div className="flex w-full flex-row items-center justify-center ">
           <h1 className="w-full text-start">
             <p className="flex h-16 items-center justify-start p-4">
-              #{playlistName}
+              {playlistName}
             </p>
           </h1>
 
-          <PlayButton tagId={tagId} />
+          <PlayButton genreId={genreId} />
         </div>
         {/* 플리 박스 */}
         <div className="bg-gray-650 flex h-auto w-full flex-col items-center rounded-2xl p-8">
@@ -95,7 +96,7 @@ function page(props: { params: { tagId: string } }) {
                 like={track.likes}
                 isLiked={track.likes_flag}
                 trackId={track.track_id}
-                playlistId={tagId}
+                playlistId={genreId}
                 isEdit={false}
               />
             )),

--- a/src/app/genre/[genreId]/page.tsx
+++ b/src/app/genre/[genreId]/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 /* eslint-disable function-paren-newline */
 /* eslint-disable no-shadow */
 /* eslint-disable no-console */
@@ -14,6 +15,7 @@
 import { fetchGenreDetail } from '@/api/playlist.ts';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
 import PlayButton from './PlayButton.tsx';
 import MusicElement from './MusicElement.tsx';
 
@@ -67,7 +69,33 @@ function page(props: { params: { genreId: string } }) {
     <div className="flex h-full w-full flex-col items-end justify-end overflow-hidden">
       <div className="h-full w-10/12 pr-8">
         {/* 플리 제목 및 플레이 아이콘 */}
-        <div className="flex w-full flex-row items-center justify-center ">
+
+        <div className="relative flex h-80 w-full overflow-hidden">
+          <Image
+            src={data.pages['0'].genre_image}
+            alt="playlist"
+            className="absolute left-0 top-0 h-full w-full"
+            objectFit="cover"
+            layout="fill"
+          />
+          <div
+            className="bg-gray-650  absolute bottom-0 left-0 flex h-full w-full items-end justify-end p-4 text-white"
+            style={{
+              background:
+                'linear-gradient(to top, rgba(26, 26, 26, 1) 10%,rgba(26, 26, 26, 0.95) 30%,  rgba(26, 26, 26, 0.1) 100%)',
+            }}
+          >
+            <h1 className="w-full text-start">
+              <p className="flex h-16 items-center justify-start p-4">
+                {playlistName}
+              </p>
+            </h1>
+
+            <PlayButton genreId={genreId} />
+          </div>
+        </div>
+
+        {/* <div className="flex w-full flex-row items-center justify-center ">
           <h1 className="w-full text-start">
             <p className="flex h-16 items-center justify-start p-4">
               {playlistName}
@@ -75,7 +103,7 @@ function page(props: { params: { genreId: string } }) {
           </h1>
 
           <PlayButton genreId={genreId} />
-        </div>
+        </div> */}
         {/* 플리 박스 */}
         <div className="bg-gray-650 flex h-auto w-full flex-col items-center rounded-2xl p-8">
           <div className="flex w-full flex-row">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-sync-scripts */
 /* eslint-disable import/extensions */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable no-undef */
@@ -25,6 +26,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
+      <head>
+        <link
+          href="https://cdn.jsdelivr.net/npm/@sweetalert2/theme-dark@4/dark.css"
+          rel="stylesheet"
+        />
+        <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.js"></script>
+      </head>
       <body className={inter.className}>
         <link
           rel="icon"

--- a/src/app/main/Genre.tsx
+++ b/src/app/main/Genre.tsx
@@ -12,6 +12,7 @@ import ForwardIcon from '@mui/icons-material/ArrowForwardIos';
 import PlayCircleIcon from '@mui/icons-material/PlayCircle';
 import { ThemeProvider } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
 import { GenreMusicProps } from '../../types/genre.ts';
 import theme from '../styles/theme.ts';
 import { fetchGenrePlaylist } from '../../api/playlist.ts';
@@ -54,14 +55,15 @@ function GenreMusic({
         className={`flex h-full w-full flex-col rounded-2xl bg-genre-${bgColor} mx-4`}
       >
         {/* 위에 단색 배경바 */}
-        <div
+        <Link
+          href={`/genre/${bgColor / 100}`}
           className={`flex h-20 w-full flex-row items-center rounded-t-2xl p-6 bg-nv-${bgColor}`}
         >
           <p className="text-md w-10/12 font-bold text-black">{genre}</p>
           <IconButton>
             <PlayCircleIcon style={{ fontSize: 50, opacity: 0.7 }} />
           </IconButton>
-        </div>
+        </Link>
 
         {/* 음악 정보 */}
         {musicList.map((music, index) => (

--- a/src/app/main/SystemPlaylist.tsx
+++ b/src/app/main/SystemPlaylist.tsx
@@ -36,22 +36,23 @@ function SystemPlaylistComponent() {
   }
   return (
     <ThemeProvider theme={theme}>
-      <div className="w-1/12 h-full flex flex-row justify-center items-center z-30 bg-gray-650">
+      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
       </div>
-      <div className="w-11/12 h-full flex flex-row justify-start items-start">
+      <div className="flex h-full w-11/12 flex-row items-start justify-start">
         {data.content.map((content: any, index: number) => (
           <AlbumCoverSystem
             key={index}
             image={content.tracks[0].thumbnail_image}
             title={content.playlist_name}
             Id={content.playlist_id}
+            curation={''}
           />
         ))}
       </div>
-      <div className="w-1/12 h-full flex flex-row justify-center items-center z-30 bg-gray-650">
+      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/main/Tag.tsx
+++ b/src/app/main/Tag.tsx
@@ -42,7 +42,8 @@ function Tag() {
               key={i}
               image={data.content[i].tag_image}
               title={data.content[i].tag_name}
-              Id={-1}
+              Id={data.content[i].tag_id}
+              curation="tag"
             />
           </div>,
         );
@@ -58,15 +59,15 @@ function Tag() {
 
   return (
     <ThemeProvider theme={theme}>
-      <div className="w-1/12 h-full flex flex-row justify-center items-center z-30 bg-gray-650">
+      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
       </div>
-      <div className="w-11/12 h-full flex flex-row items-center justify-start">
+      <div className="flex h-full w-11/12 flex-row items-center justify-start">
         {musicList}
       </div>
-      <div className="w-1/12 h-full flex flex-row justify-center items-center z-30 bg-gray-650">
+      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/playlist/[playlistId]/MusicElement.tsx
+++ b/src/app/playlist/[playlistId]/MusicElement.tsx
@@ -12,6 +12,7 @@ import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import { likes, disLikes } from '@/api/music.ts';
 import { useState } from 'react';
+import Link from 'next/link';
 import theme from '../../styles/theme.ts';
 
 export default function MusicElement({
@@ -72,10 +73,13 @@ export default function MusicElement({
   return (
     <ThemeProvider theme={theme}>
       <div className="hover-bg-opacity flex w-full flex-row items-center justify-start py-4">
-        <div className="flex w-full flex-row items-center px-12">
+        <Link
+          href={`/track/${trackId}`}
+          className="flex w-full flex-row items-center px-12"
+        >
           <img src={image} alt="Album cover" className="h-24 w-24 rounded-lg" />
           <p className="mx-6 flex text-2xl">{title}</p>
-        </div>
+        </Link>
         <div className="flex w-2/12 items-center justify-center text-2xl">
           <IconButton onClick={handleLike}>
             {isLikedStore ? (

--- a/src/app/playlist/[playlistId]/MusicElement.tsx
+++ b/src/app/playlist/[playlistId]/MusicElement.tsx
@@ -93,15 +93,12 @@ export default function MusicElement({
       if (result.isConfirmed) {
         deleteTrack(playlistId, trackId)
           .then(() => {
-            console.log('음악 삭제 성공');
             setDeleteAnimation(true);
             setTimeout(() => {
               setIsTrack(false);
             }, 500);
           })
-          .catch(() => {
-            console.log('음악 삭제 실패');
-          });
+          .catch(() => {});
       }
     });
   };

--- a/src/app/playlist/[playlistId]/MusicElement.tsx
+++ b/src/app/playlist/[playlistId]/MusicElement.tsx
@@ -7,7 +7,7 @@
 import { MusicElementProps } from '@/types/playlist.ts';
 import numeral from 'numeral';
 import { IconButton, ThemeProvider } from '@mui/material';
-import PlayCircleIcon from '@mui/icons-material/PlayCircle';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import { likes, disLikes } from '@/api/music.ts';
@@ -152,10 +152,7 @@ export default function MusicElement({
           </div>
           <div className="flex w-24 items-center justify-center">
             <IconButton>
-              <PlayCircleIcon
-                color="primary"
-                style={{ fontSize: 50, opacity: 1 }}
-              />
+              <PlayArrowIcon color="primary" fontSize="large" />
             </IconButton>
           </div>
         </div>

--- a/src/app/playlist/[playlistId]/MusicElement.tsx
+++ b/src/app/playlist/[playlistId]/MusicElement.tsx
@@ -13,6 +13,9 @@ import FavoriteIcon from '@mui/icons-material/Favorite';
 import { likes, disLikes } from '@/api/music.ts';
 import { useState } from 'react';
 import Link from 'next/link';
+import CancelIcon from '@mui/icons-material/Cancel';
+import Swal from 'sweetalert2';
+import { deleteTrack } from '@/api/playlist.ts';
 import theme from '../../styles/theme.ts';
 
 export default function MusicElement({
@@ -21,8 +24,12 @@ export default function MusicElement({
   like,
   isLiked,
   trackId,
+  playlistId,
+  isEdit,
 }: MusicElementProps) {
   const [isLikedStore, setIsLikedStore] = useState(isLiked);
+  const [deleteAnimation, setDeleteAnimation] = useState(false);
+  const [isTrack, setIsTrack] = useState(true);
   const [likeStore, setLikeStore] = useState(like);
   const [formattedLike, setFormattedLike] = useState(
     likeStore > 999
@@ -70,36 +77,89 @@ export default function MusicElement({
     }
   };
 
+  const clearMusic = () => {
+    Swal.fire({
+      title: '정말 삭제 하시겠어요?',
+      text: '삭제하면 되돌릴 수 없어요!',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#d33',
+      cancelButtonColor: '#777',
+      confirmButtonText: 'Yes, delete it!',
+      customClass: {
+        popup: 'swal2-dark', // 여기에 다크 테마 클래스 추가
+      },
+    }).then((result) => {
+      if (result.isConfirmed) {
+        deleteTrack(playlistId, trackId)
+          .then(() => {
+            console.log('음악 삭제 성공');
+            setDeleteAnimation(true);
+            setTimeout(() => {
+              setIsTrack(false);
+            }, 500);
+          })
+          .catch(() => {
+            console.log('음악 삭제 실패');
+          });
+      }
+    });
+  };
+
   return (
     <ThemeProvider theme={theme}>
-      <div className="hover-bg-opacity flex w-full flex-row items-center justify-start py-4">
-        <Link
-          href={`/track/${trackId}`}
-          className="flex w-full flex-row items-center px-12"
+      {isTrack && (
+        <div
+          className={`hover-bg-opacity flex w-full flex-row items-center justify-start py-4 ${deleteAnimation ? 'transform-playlist-delete' : null} `}
         >
-          <img src={image} alt="Album cover" className="h-24 w-24 rounded-lg" />
-          <p className="mx-6 flex text-2xl">{title}</p>
-        </Link>
-        <div className="flex w-2/12 items-center justify-center text-2xl">
-          <IconButton onClick={handleLike}>
-            {isLikedStore ? (
-              <FavoriteIcon color="primary" fontSize="inherit" />
+          <div
+            className={`flex items-center justify-center ${isEdit ? 'transform-playlist-edit transform-playlist-opacity' : 'transform-playlist-normal opacity-0'}`}
+          >
+            {isEdit ? (
+              <IconButton className="mx-2" onClick={clearMusic}>
+                <CancelIcon
+                  className="h-10 w-10"
+                  color="error"
+                  fontSize="large"
+                />
+              </IconButton>
             ) : (
-              <FavoriteBorderIcon color="primary" />
+              <div className="w-14" />
             )}
-          </IconButton>
-
-          {formattedLike}
-        </div>
-        <div className="flex w-24 items-center justify-center">
-          <IconButton>
-            <PlayCircleIcon
-              color="primary"
-              style={{ fontSize: 50, opacity: 1 }}
+          </div>
+          <Link
+            href={`/track/${trackId}`}
+            className={`flex w-full flex-row items-center ${isEdit ? 'transform-playlist-edit' : 'transform-playlist-normal'}`}
+          >
+            <img
+              src={image}
+              alt="Album cover"
+              className="h-24 w-24 rounded-lg"
             />
-          </IconButton>
+            <p className="mx-6 flex text-2xl">{title}</p>
+          </Link>
+
+          <div className="flex w-2/12 items-center justify-center text-2xl">
+            <IconButton onClick={handleLike}>
+              {isLikedStore ? (
+                <FavoriteIcon color="primary" fontSize="inherit" />
+              ) : (
+                <FavoriteBorderIcon color="primary" />
+              )}
+            </IconButton>
+
+            {formattedLike}
+          </div>
+          <div className="flex w-24 items-center justify-center">
+            <IconButton>
+              <PlayCircleIcon
+                color="primary"
+                style={{ fontSize: 50, opacity: 1 }}
+              />
+            </IconButton>
+          </div>
         </div>
-      </div>
+      )}
     </ThemeProvider>
   );
 }

--- a/src/app/playlist/[playlistId]/MusicElement.tsx
+++ b/src/app/playlist/[playlistId]/MusicElement.tsx
@@ -21,8 +21,6 @@ export default function MusicElement({
   isLiked,
   trackId,
 }: MusicElementProps) {
-  // const formattedLike =
-  //   like > 999 ? numeral(like).format('0.0a') : numeral(like).format('0a');
   const [isLikedStore, setIsLikedStore] = useState(isLiked);
   const [likeStore, setLikeStore] = useState(like);
   const [formattedLike, setFormattedLike] = useState(

--- a/src/app/playlist/[playlistId]/MusicElement.tsx
+++ b/src/app/playlist/[playlistId]/MusicElement.tsx
@@ -71,8 +71,6 @@ export default function MusicElement({
     }
   };
 
-  console.log('likeStore: ', likeStore, 'formattedLike: ', formattedLike);
-
   return (
     <ThemeProvider theme={theme}>
       <div className="hover-bg-opacity flex w-full flex-row items-center justify-start py-4">

--- a/src/app/playlist/[playlistId]/MusicElement.tsx
+++ b/src/app/playlist/[playlistId]/MusicElement.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable @next/next/no-img-element */
-
 'use client';
 
+/* eslint-disable @next/next/no-img-element */
 /* eslint-disable object-curly-newline */
 /* eslint-disable operator-linebreak */
 
@@ -12,6 +11,7 @@ import PlayCircleIcon from '@mui/icons-material/PlayCircle';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import { likes, disLikes } from '@/api/music.ts';
+import { useState } from 'react';
 import theme from '../../styles/theme.ts';
 
 export default function MusicElement({
@@ -21,16 +21,57 @@ export default function MusicElement({
   isLiked,
   trackId,
 }: MusicElementProps) {
-  const formattedLike =
-    like > 999 ? numeral(like).format('0.0a') : numeral(like).format('0a');
+  // const formattedLike =
+  //   like > 999 ? numeral(like).format('0.0a') : numeral(like).format('0a');
+  const [isLikedStore, setIsLikedStore] = useState(isLiked);
+  const [likeStore, setLikeStore] = useState(like);
+  const [formattedLike, setFormattedLike] = useState(
+    likeStore > 999
+      ? numeral(likeStore).format('0.0a')
+      : numeral(likeStore).format('0a'),
+  );
 
   const handleLike = async () => {
-    if (isLiked) {
-      await likes(trackId);
+    if (isLikedStore) {
+      setIsLikedStore(false);
+      setLikeStore(likeStore - 1);
+      setFormattedLike(
+        likeStore > 999
+          ? numeral(likeStore - 1).format('0.0a')
+          : numeral(likeStore - 1).format('0a'),
+      );
+      disLikes(trackId).catch(() => {
+        // API 호출이 실패하면 상태를 되돌립니다
+        setIsLikedStore(true);
+        setLikeStore(likeStore);
+        setFormattedLike(
+          likeStore > 999
+            ? numeral(likeStore).format('0.0a')
+            : numeral(likeStore).format('0a'),
+        );
+      });
     } else {
-      await disLikes(trackId);
+      setIsLikedStore(true);
+      setLikeStore(likeStore + 1);
+      setFormattedLike(
+        likeStore > 999
+          ? numeral(likeStore + 1).format('0.0a')
+          : numeral(likeStore + 1).format('0a'),
+      );
+      likes(trackId).catch(() => {
+        // API 호출이 실패하면 상태를 되돌립니다
+        setIsLikedStore(false);
+        setLikeStore(likeStore);
+        setFormattedLike(
+          likeStore > 999
+            ? numeral(likeStore).format('0.0a')
+            : numeral(likeStore).format('0a'),
+        );
+      });
     }
   };
+
+  console.log('likeStore: ', likeStore, 'formattedLike: ', formattedLike);
 
   return (
     <ThemeProvider theme={theme}>
@@ -41,7 +82,7 @@ export default function MusicElement({
         </div>
         <div className="flex w-2/12 items-center justify-center text-2xl">
           <IconButton onClick={handleLike}>
-            {isLiked ? (
+            {isLikedStore ? (
               <FavoriteIcon color="primary" fontSize="inherit" />
             ) : (
               <FavoriteBorderIcon color="primary" />

--- a/src/app/playlist/[playlistId]/PlayButton.tsx
+++ b/src/app/playlist/[playlistId]/PlayButton.tsx
@@ -9,7 +9,7 @@ import theme from '../../styles/theme.ts';
 function PlayButton(playlistId: any) {
   return (
     <ThemeProvider theme={theme}>
-      <IconButton className="mx-28">
+      <IconButton className="mx-8">
         <PlayCircleIcon color="primary" style={{ fontSize: 60, opacity: 1 }} />
       </IconButton>
     </ThemeProvider>

--- a/src/app/playlist/[playlistId]/page.tsx
+++ b/src/app/playlist/[playlistId]/page.tsx
@@ -115,8 +115,10 @@ function page(props: any) {
   };
 
   useEffect(() => {
-    if (data === undefined) return;
-    setPlaylistName(data.pages['0'].playlist_name);
+    if (data !== undefined) {
+      setPlaylistName(data.pages['0'].playlist_name);
+      setIsFollow(data.pages['0'].is_follow);
+    }
   }, [data]);
 
   if (isLoading || data === undefined) return <div>Loading...</div>;

--- a/src/app/playlist/[playlistId]/page.tsx
+++ b/src/app/playlist/[playlistId]/page.tsx
@@ -1,9 +1,10 @@
-/* eslint-disable no-nested-ternary */
-/* eslint-disable react/no-unescaped-entities */
 /* eslint-disable function-paren-newline */
 /* eslint-disable no-shadow */
-/* eslint-disable consistent-return */
+/* eslint-disable no-console */
+/* eslint-disable operator-linebreak */
+/* eslint-disable no-nested-ternary */
 /* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable consistent-return */
 /* eslint-disable object-curly-newline */
 /* eslint-disable implicit-arrow-linebreak */
 /* eslint-disable react-hooks/rules-of-hooks */
@@ -11,9 +12,11 @@
 'use client';
 
 import {
+  deleteFollow,
   deletePlaylist,
   fetchPlaylistDetail,
   patchPlaylistName,
+  postFollow,
 } from '@/api/playlist.ts';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
@@ -26,6 +29,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import Swal from 'sweetalert2';
 import { useRouter } from 'next/navigation';
+import SubscriptionsIcon from '@mui/icons-material/Subscriptions';
 import PlayButton from './PlayButton.tsx';
 import MusicElement from './MusicElement.tsx';
 
@@ -37,6 +41,7 @@ function page(props: any) {
   const open = Boolean(anchorEl);
   const [editOpen, setEditOpen] = useState(false);
   const [playlistName, setPlaylistName] = useState('');
+  const [isFollow, setIsFollow] = useState(false);
   const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteQuery({
     queryKey: ['Playlist Details', playlistId],
     queryFn: ({ pageParam }) =>
@@ -127,7 +132,7 @@ function page(props: any) {
               <div className="flex flex-row items-center justify-start">
                 <input
                   type="text"
-                  className="bg-gray-650 h-16 rounded-2xl p-4 text-4xl text-white focus:outline-none"
+                  className="bg-gray-650 h-16 w-auto rounded-2xl p-4 text-4xl text-white focus:outline-none"
                   value={playlistName}
                   onChange={(e) => setPlaylistName(e.target.value)}
                 />
@@ -144,10 +149,46 @@ function page(props: any) {
                 </button>
               </div>
             ) : (
-              <p>{playlistName}</p>
+              <p className="flex h-16 items-center justify-start p-4">
+                {playlistName}
+              </p>
             )}
           </h1>
+          {/* 플레이리스트 생성자가 아닐 경우 보여주는 팔로우 버튼 */}
+          {!data.pages['0'].is_owner &&
+            data.pages['0'].is_public &&
+            (isFollow ? (
+              <button
+                onClick={() => {
+                  setIsFollow(false);
+                  deleteFollow(playlistId).catch(() => {
+                    setIsFollow(true);
+                    console.error('언팔로우 실패');
+                  });
+                }}
+                className="flex h-14 w-44 items-center justify-center rounded-2xl bg-zinc-700 p-2 text-2xl text-white focus:outline-none"
+              >
+                언팔로우
+              </button>
+            ) : (
+              <button
+                onClick={() => {
+                  setIsFollow(true);
+                  postFollow(playlistId).catch(() => {
+                    setIsFollow(false);
+                    console.error('팔로우 실패');
+                  });
+                }}
+                className="flex h-14 w-44 items-center justify-center rounded-2xl bg-zinc-200 p-2 text-2xl text-black focus:outline-none"
+              >
+                <SubscriptionsIcon className="mr-3" />
+                팔로우
+              </button>
+            ))}
+
           <PlayButton playlistId={playlistId} />
+
+          {/* 플레이리스트 생성자 일 경우 보여주는 메뉴 */}
           {data.pages['0'].is_owner && (
             <ThemeProvider theme={theme}>
               <IconButton className="mr-8" onClick={handleClick}>
@@ -171,7 +212,7 @@ function page(props: any) {
                   }}
                 >
                   <EditIcon className="mx-2" />
-                  플레이리스트 이름 수정
+                  플레이리스트 수정
                 </MenuItem>
                 <MenuItem
                   className="h-12 text-lg"
@@ -204,6 +245,8 @@ function page(props: any) {
                 like={track.likes}
                 isLiked={track.likes_flag}
                 trackId={track.track_id}
+                playlistId={playlistId}
+                isEdit={editOpen}
               />
             )),
           )}

--- a/src/app/playlist/[playlistId]/page.tsx
+++ b/src/app/playlist/[playlistId]/page.tsx
@@ -55,8 +55,6 @@ function page(props: any) {
     };
   }, [hasNextPage, fetchNextPage]);
 
-  console.log('next? ', hasNextPage);
-
   if (isLoading || data === undefined) return <div>Loading...</div>;
   return (
     <div className="flex h-full w-full flex-col items-end justify-end overflow-hidden">

--- a/src/app/playlist/[playlistId]/page.tsx
+++ b/src/app/playlist/[playlistId]/page.tsx
@@ -1,24 +1,35 @@
+/* eslint-disable no-nested-ternary */
+/* eslint-disable react/no-unescaped-entities */
+/* eslint-disable function-paren-newline */
+/* eslint-disable no-shadow */
 /* eslint-disable consistent-return */
 /* eslint-disable react-hooks/exhaustive-deps */
-/* eslint-disable function-paren-newline */
-/* eslint-disable indent */
-/* eslint-disable operator-linebreak */
-/* eslint-disable no-shadow */
 /* eslint-disable object-curly-newline */
-/* eslint-disable react-hooks/rules-of-hooks */
 /* eslint-disable implicit-arrow-linebreak */
+/* eslint-disable react-hooks/rules-of-hooks */
 
 'use client';
 
-import { fetchPlaylistDetail } from '@/api/playlist.ts';
+import { fetchPlaylistDetail, patchPlaylistName } from '@/api/playlist.ts';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { IconButton, ThemeProvider } from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import theme from '@/app/styles/theme.ts';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
 import PlayButton from './PlayButton.tsx';
 import MusicElement from './MusicElement.tsx';
 
 function page(props: any) {
   const playlistId = decodeURIComponent(props.params.playlistId);
   const renderSize = 12;
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  const [editOpen, setEditOpen] = useState(false);
+  const [playlistName, setPlaylistName] = useState('');
   const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteQuery({
     queryKey: ['Playlist Details', playlistId],
     queryFn: ({ pageParam }) =>
@@ -33,6 +44,12 @@ function page(props: any) {
     },
   });
   const loadMoreRef = useRef(null);
+  const handleClick = (event: any) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
   useEffect(() => {
     if (!hasNextPage) return;
@@ -55,14 +72,77 @@ function page(props: any) {
     };
   }, [hasNextPage, fetchNextPage]);
 
+  useEffect(() => {
+    if (data === undefined) return;
+    setPlaylistName(data.pages['0'].playlist_name);
+  }, [data]);
+
   if (isLoading || data === undefined) return <div>Loading...</div>;
   return (
     <div className="flex h-full w-full flex-col items-end justify-end overflow-hidden">
       <div className="h-full w-10/12 pr-8">
         {/* 플리 제목 및 플레이 아이콘 */}
         <div className="flex w-full flex-row items-center justify-center ">
-          <h1 className="w-full text-start">{data.pages['0'].playlist_name}</h1>
+          <h1 className="w-full text-start">
+            {playlistId === 'like' ? (
+              '좋아요 누른 곡'
+            ) : editOpen ? (
+              <div className="flex flex-row items-center justify-start">
+                <input
+                  type="text"
+                  className="bg-gray-650 h-16 rounded-2xl p-4 text-4xl text-white focus:outline-none"
+                  value={playlistName}
+                  onChange={(e) => setPlaylistName(e.target.value)}
+                />
+                <button
+                  type="button"
+                  className="mx-2 flex h-14 w-28 items-center justify-center rounded-2xl bg-zinc-700 p-2 text-2xl text-white focus:outline-none"
+                  onClick={() => {
+                    setEditOpen(false);
+                    patchPlaylistName(playlistId, playlistName);
+                  }}
+                >
+                  <EditIcon className="mr-2" />
+                  수정
+                </button>
+              </div>
+            ) : (
+              <p>{playlistName}</p>
+            )}
+          </h1>
           <PlayButton playlistId={playlistId} />
+          {data.pages['0'].is_owner && (
+            <ThemeProvider theme={theme}>
+              <IconButton className="mr-8" onClick={handleClick}>
+                <MoreVertIcon color="primary" fontSize="large" />
+              </IconButton>
+              <Menu
+                id="basic-menu"
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleClose}
+                MenuListProps={{
+                  'aria-labelledby': 'basic-button',
+                  className: 'bg-zinc-800 text-white w-72',
+                }}
+              >
+                <MenuItem
+                  className="h-12 text-lg"
+                  onClick={() => {
+                    handleClose();
+                    setEditOpen(true);
+                  }}
+                >
+                  <EditIcon className="mx-2" />
+                  플레이리스트 이름 수정
+                </MenuItem>
+                <MenuItem className="h-12 text-lg" onClick={handleClose}>
+                  <DeleteIcon className="mx-2" />
+                  플레이리스트 삭제
+                </MenuItem>
+              </Menu>
+            </ThemeProvider>
+          )}
         </div>
         {/* 플리 박스 */}
         <div className="bg-gray-650 flex h-auto w-full flex-col items-center rounded-2xl p-8">

--- a/src/app/playlist/[playlistId]/page.tsx
+++ b/src/app/playlist/[playlistId]/page.tsx
@@ -10,7 +10,11 @@
 
 'use client';
 
-import { fetchPlaylistDetail, patchPlaylistName } from '@/api/playlist.ts';
+import {
+  deletePlaylist,
+  fetchPlaylistDetail,
+  patchPlaylistName,
+} from '@/api/playlist.ts';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import { IconButton, ThemeProvider } from '@mui/material';
@@ -20,10 +24,13 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import Swal from 'sweetalert2';
+import { useRouter } from 'next/navigation';
 import PlayButton from './PlayButton.tsx';
 import MusicElement from './MusicElement.tsx';
 
 function page(props: any) {
+  const router = useRouter();
   const playlistId = decodeURIComponent(props.params.playlistId);
   const renderSize = 12;
   const [anchorEl, setAnchorEl] = useState(null);
@@ -71,6 +78,36 @@ function page(props: any) {
       if (loadMoreRef.current) observer.disconnect();
     };
   }, [hasNextPage, fetchNextPage]);
+
+  const handleDeletePlaylist = async () => {
+    setEditOpen(false);
+    handleClose();
+    Swal.fire({
+      title: '정말 삭제 하시겠어요?',
+      text: '삭제하면 되돌릴 수 없어요!',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#d33',
+      cancelButtonColor: '#777',
+      confirmButtonText: 'Yes, delete it!',
+      customClass: {
+        popup: 'swal2-dark', // 여기에 다크 테마 클래스 추가
+      },
+    }).then((result) => {
+      if (result.isConfirmed) {
+        Swal.fire({
+          title: '삭제 완료',
+          text: '플레이리스트가 삭제 되었습니다!',
+          icon: 'success',
+          customClass: {
+            popup: 'swal2-dark', // 여기에 다크 테마 클래스 추가
+          },
+        });
+        deletePlaylist(playlistId);
+        router.push('/playlist');
+      }
+    });
+  };
 
   useEffect(() => {
     if (data === undefined) return;
@@ -136,7 +173,10 @@ function page(props: any) {
                   <EditIcon className="mx-2" />
                   플레이리스트 이름 수정
                 </MenuItem>
-                <MenuItem className="h-12 text-lg" onClick={handleClose}>
+                <MenuItem
+                  className="h-12 text-lg"
+                  onClick={handleDeletePlaylist}
+                >
                   <DeleteIcon className="mx-2" />
                   플레이리스트 삭제
                 </MenuItem>

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -219,3 +219,24 @@ em {
 #card-back {
   transform: rotateY(180deg);
 }
+
+/* 아래 4개 CSS는 플레이리스트 상세 페이지에서 사용하는 속성들 입니다. */
+.transform-playlist-edit {
+  transform: translateX(0rem);
+  transition: transform 0.5s;
+}
+
+.transform-playlist-normal {
+  transform: translateX(-1.25rem);
+  transition: transform 0.5s;
+}
+
+.transform-playlist-opacity {
+  opacity: 1;
+  transition: opacity 1s;
+}
+
+.transform-playlist-delete {
+  transform: translateX(200%);
+  transition: transform 1.5s;
+}

--- a/src/app/styles/theme.ts
+++ b/src/app/styles/theme.ts
@@ -10,6 +10,10 @@ const theme = createTheme({
       // 흰색
       main: '#ffffff',
     },
+    error: {
+      // 빨간색
+      main: '#FF4444',
+    },
   },
 });
 

--- a/src/app/tag/[tagId]/MusicElement.tsx
+++ b/src/app/tag/[tagId]/MusicElement.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+/* eslint-disable @next/next/no-img-element */
+/* eslint-disable object-curly-newline */
+/* eslint-disable operator-linebreak */
+
+import { MusicElementProps } from '@/types/playlist.ts';
+import numeral from 'numeral';
+import { IconButton, ThemeProvider } from '@mui/material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import { likes, disLikes } from '@/api/music.ts';
+import { useState } from 'react';
+import Link from 'next/link';
+import theme from '../../styles/theme.ts';
+
+export default function MusicElement({
+  image,
+  title,
+  like,
+  isLiked,
+  trackId,
+}: MusicElementProps) {
+  const [isLikedStore, setIsLikedStore] = useState(isLiked);
+  const [likeStore, setLikeStore] = useState(like);
+  const [formattedLike, setFormattedLike] = useState(
+    likeStore > 999
+      ? numeral(likeStore).format('0.0a')
+      : numeral(likeStore).format('0a'),
+  );
+
+  const handleLike = async () => {
+    if (isLikedStore) {
+      setIsLikedStore(false);
+      setLikeStore(likeStore - 1);
+      setFormattedLike(
+        likeStore > 999
+          ? numeral(likeStore - 1).format('0.0a')
+          : numeral(likeStore - 1).format('0a'),
+      );
+      disLikes(trackId).catch(() => {
+        // API 호출이 실패하면 상태를 되돌립니다
+        setIsLikedStore(true);
+        setLikeStore(likeStore);
+        setFormattedLike(
+          likeStore > 999
+            ? numeral(likeStore).format('0.0a')
+            : numeral(likeStore).format('0a'),
+        );
+      });
+    } else {
+      setIsLikedStore(true);
+      setLikeStore(likeStore + 1);
+      setFormattedLike(
+        likeStore > 999
+          ? numeral(likeStore + 1).format('0.0a')
+          : numeral(likeStore + 1).format('0a'),
+      );
+      likes(trackId).catch(() => {
+        // API 호출이 실패하면 상태를 되돌립니다
+        setIsLikedStore(false);
+        setLikeStore(likeStore);
+        setFormattedLike(
+          likeStore > 999
+            ? numeral(likeStore).format('0.0a')
+            : numeral(likeStore).format('0a'),
+        );
+      });
+    }
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div
+        className={
+          'hover-bg-opacity flex w-full flex-row items-center justify-start py-4'
+        }
+      >
+        <Link
+          href={`/track/${trackId}`}
+          className={'flex w-full flex-row items-center'}
+        >
+          <img
+            src={image}
+            alt="Album cover"
+            className="ml-10 h-24 w-24 rounded-lg"
+          />
+          <p className="mx-6 flex text-2xl">{title}</p>
+        </Link>
+
+        <div className="flex w-2/12 items-center justify-center text-2xl">
+          <IconButton onClick={handleLike}>
+            {isLikedStore ? (
+              <FavoriteIcon color="primary" fontSize="inherit" />
+            ) : (
+              <FavoriteBorderIcon color="primary" />
+            )}
+          </IconButton>
+
+          {formattedLike}
+        </div>
+        <div className="flex w-24 items-center justify-center">
+          <IconButton>
+            <PlayArrowIcon color="primary" fontSize="large" />
+          </IconButton>
+        </div>
+      </div>
+    </ThemeProvider>
+  );
+}

--- a/src/app/tag/[tagId]/PlayButton.tsx
+++ b/src/app/tag/[tagId]/PlayButton.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable no-unused-vars */
+
+'use client';
+
+import { IconButton, ThemeProvider } from '@mui/material';
+import PlayCircleIcon from '@mui/icons-material/PlayCircle';
+import theme from '../../styles/theme.ts';
+
+function PlayButton(playlistId: any) {
+  return (
+    <ThemeProvider theme={theme}>
+      <IconButton className="mx-8">
+        <PlayCircleIcon color="primary" style={{ fontSize: 60, opacity: 1 }} />
+      </IconButton>
+    </ThemeProvider>
+  );
+}
+
+export default PlayButton;

--- a/src/app/tag/[tagId]/page.tsx
+++ b/src/app/tag/[tagId]/page.tsx
@@ -1,0 +1,110 @@
+/* eslint-disable function-paren-newline */
+/* eslint-disable no-shadow */
+/* eslint-disable no-console */
+/* eslint-disable operator-linebreak */
+/* eslint-disable no-nested-ternary */
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable consistent-return */
+/* eslint-disable object-curly-newline */
+/* eslint-disable implicit-arrow-linebreak */
+/* eslint-disable react-hooks/rules-of-hooks */
+
+'use client';
+
+import { fetchTagDetail } from '@/api/playlist.ts';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+import PlayButton from './PlayButton.tsx';
+import MusicElement from './MusicElement.tsx';
+
+function page(props: { params: { tagId: string } }) {
+  const tagId = decodeURIComponent(props.params.tagId);
+  const renderSize = 12;
+  const [playlistName, setPlaylistName] = useState('');
+  const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['Tag Details', tagId],
+    queryFn: ({ pageParam }) => fetchTagDetail(tagId, pageParam, renderSize),
+    initialPageParam: 0,
+
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.tracks.next === null) {
+        return undefined;
+      }
+      return allPages.length;
+    },
+  });
+  const loadMoreRef = useRef(null);
+
+  useEffect(() => {
+    if (!hasNextPage) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          fetchNextPage();
+        }
+      },
+      {
+        root: null, // 기본적으로 브라우저 뷰포트를 root로 사용
+        rootMargin: '0px',
+        threshold: 0.1, // 타겟 요소가 10% 보이면 콜백 실행
+      },
+    );
+    if (loadMoreRef.current) observer.observe(loadMoreRef.current);
+
+    return () => {
+      if (loadMoreRef.current) observer.disconnect();
+    };
+  }, [hasNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    if (data === undefined) return;
+    setPlaylistName(data.pages['0'].tag_name);
+  }, [data]);
+
+  if (isLoading || data === undefined) return <div>Loading...</div>;
+  return (
+    <div className="flex h-full w-full flex-col items-end justify-end overflow-hidden">
+      <div className="h-full w-10/12 pr-8">
+        {/* 플리 제목 및 플레이 아이콘 */}
+        <div className="flex w-full flex-row items-center justify-center ">
+          <h1 className="w-full text-start">
+            <p className="flex h-16 items-center justify-start p-4">
+              {playlistName}
+            </p>
+          </h1>
+
+          <PlayButton tagId={tagId} />
+        </div>
+        {/* 플리 박스 */}
+        <div className="bg-gray-650 flex h-auto w-full flex-col items-center rounded-2xl p-8">
+          <div className="flex w-full flex-row">
+            <p className="flex w-full px-20 text-2xl"> 곡 정보</p>
+            <p className="flex w-2/12 items-center justify-center text-2xl">
+              좋아요
+            </p>
+            <p className="flex w-24 justify-center text-2xl ">재생</p>
+          </div>
+          <hr className="my-6 w-full border-zinc-600" />
+          {/* 음악 요소들 */}
+          {data.pages.map((page: any) =>
+            page.tracks.content.map((track: any) => (
+              <MusicElement
+                key={track.track_id}
+                image={track.thumbnail_image}
+                title={track.title}
+                like={track.likes}
+                isLiked={track.likes_flag}
+                trackId={track.track_id}
+                playlistId={tagId}
+                isEdit={false}
+              />
+            )),
+          )}
+          <div ref={loadMoreRef} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default page;

--- a/src/types/albumCover.ts
+++ b/src/types/albumCover.ts
@@ -10,4 +10,5 @@ export interface albumCoverSystemProps {
   image: string;
   title: string;
   Id: number;
+  curation: string;
 }

--- a/src/types/playlist.ts
+++ b/src/types/playlist.ts
@@ -4,4 +4,6 @@ export interface MusicElementProps {
   like: number;
   isLiked: boolean;
   trackId: string;
+  playlistId: string;
+  isEdit: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,6 +623,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@sweetalert2/theme-dark@^5.0.16":
+  version "5.0.16"
+  resolved "https://registry.yarnpkg.com/@sweetalert2/theme-dark/-/theme-dark-5.0.16.tgz#2b423df3ab5031a47214f733425e63aa381655ef"
+  integrity sha512-SFXEVfp9jmaBLhYEeRilrcpQP/sQimfjtZdvazJ+l5jEdNVKDkPD/CD3T7V8VqUqk/q2zUBSvr0WOMrHoAvfCA==
+
 "@tanstack/query-core@5.29.0":
   version "5.29.0"
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.29.0.tgz#d0b3d12c07d5a47f42ab0c1ed4f317106f3d4b20"


### PR DESCRIPTION
### PR Type

<!— Please check the one that applies to this PR using "[x]" —>

- [x] Feat(기능 추가)
- [ ] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

---

### Summary
플레이리스트 상세페이지 기능 구현 
---

### Description
플레이리스트 상세페이지 기능 구현 완료 했습니다.
플레이리스트 상세페이지는 크게 총 네가지가 있습니다. 사용자가 만든 플레이리스트, 시스템 플레이리스트, 태그별 플레이리스트, 장르별 플레이리스트가 있는데 시스템 플레이리스트를 제외한 다른 플레이리스트를 모두 구현했습니다. 각 플레이리스트에서 좋아요 기능과 무한스크롤 기능은 구현이 되어있지만 재생기능은 새로운 issue에서 작업하겠습니다.
 
- 사용자가 만든 플레이리스트

https://github.com/DreamVault-2024/dreamvalut-frontend/assets/133188752/1c1ff9c9-dd8d-4b1e-be20-3bb4123d8d44

사용자(본인)가 만든 플레이리스트 입니다. 본인이 만들었다면 위와같이 메뉴버튼이 보이고 플레이리스트를 수정할 수 있습니다.

https://github.com/DreamVault-2024/dreamvalut-frontend/assets/133188752/f29cb819-5d7c-44ba-b90a-db58556ba27d

다른 사용자가 만든 플레이리스트입니다. 플레이리스트 수정이 불가능하지만 팔로우와 언팔로우 기능을 사용할 수 있습니다.

- 장르별 플레이리스트

https://github.com/DreamVault-2024/dreamvalut-frontend/assets/133188752/94a3f9a3-4b2b-4542-9e5c-ae57d4ff2ece

장르별 플레이리스트입니다. 장르는 갯수와 종류가 정해져있고 그에 따른 이미지가 있습니다. 그래서 그에 따른 이미지로 배경을 상단에 그라데이션으로 두었습니다. 하지만 어떤 장르를 클릭했을 때 사용자가 클릭한 장르로 페이지가 넘어가는 기능은 아직 구현하지 못했고 지금은 랜덤의 장르로 페이지가 이동을 합니다. 이건 구현하려면 해야할게 많은데 디자인 수정할 때 어차피 해야하는 것들이라 나중에 디자인 수정하면서 진행할 예정입니다.

- 태그별 플레이리스트

https://github.com/DreamVault-2024/dreamvalut-frontend/assets/133188752/160da901-1b7b-4de7-a644-e4724196de72

태그별 플레이리스트입니다. 태그별 플리는 제목 옆에 해시태그를 보이도록 구성했습니다. 참고로 메인페이지에서 태그의 썸네일이 나오지 않는 이유는 현재 백엔드에서 썸네일 이미지를 주는 로직을 구현하지 않아서 나오지 않습니다. 백엔드에서 로직이 구현되면 수정할 예정입니다.

그 외에 develop 내용 모두 pull 받고 merge 했고 오류도 전부 수정했습니다. 그리고 S3 버킷에 담겨져 있는 이미지 URL을 Image 컴포넌트에서 사용하기 위해 next.config.mjs 파일에 도메인 추가해 줬습니다.

---

### Issue Number
38

