### PR TITLE
[feat] 재생 목록 API 버그 수정

### DIFF
--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -6,6 +6,25 @@
 import axios from 'axios';
 import { getCookie } from '@/app/Cookies';
 
+export async function getStreamTrack(pageIndex: number, size: number) {
+  try {
+    const accessToken = await getCookie('accessToken');
+    const response = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_URL}/tracks/users/played?page=${pageIndex}&size=${size}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('API Fetch Error (stream track):', error);
+    throw error;
+  }
+}
+
 // 플레이리스트 생성
 export async function fetchTags(pageIndex: number) {
   try {

--- a/src/app/track/[trackId]/page.tsx
+++ b/src/app/track/[trackId]/page.tsx
@@ -23,7 +23,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
-import { getMyPlaylists, getPlaylist } from '@/api/playlist';
+import { getStreamTrack } from '@/api/playlist';
 import { getMusic, disLikes, likes } from '@/api/music';
 import theme from '@/app/styles/theme';
 import { useSharedAudio } from '@/app/components/audio/Audio';
@@ -115,17 +115,14 @@ export default function MusicPage(props: any) {
   // API 호출
   // 특정 플레이리스트 가져오기
   const { data, isLoading } = useQuery({
-    queryKey: ['playlist'],
-    queryFn: getPlaylist,
-    // () => {
-    //   getPlaylist(selectedPlaylist);
-    // },
+    queryKey: ['Streaming Track'],
+    queryFn: () => getStreamTrack(0, 5), // 하드코딩, 추후 수정 필요
   });
 
   // 모든 플레이리스트 가져오기
   const { data: listData, isLoading: listLoading } = useQuery({
-    queryKey: ['AllPlaylist'],
-    queryFn: getMyPlaylists,
+    queryKey: ['Streaming Track'],
+    queryFn: () => getStreamTrack(0, 5), // 하드코딩, 추후 수정 필요
   });
 
   const [isLiked, setIsLiked] = useState<boolean>(false);
@@ -323,15 +320,15 @@ export default function MusicPage(props: any) {
               >
                 {listLoading
                   ? 'loading'
-                  : listData.data.playlists.map((e: any) => (
+                  : listData.content.map((e: any) => (
                       <MenuItem
-                        key={e.playlist_id}
+                        key={e.track_id}
                         onClick={() => {
                           handleClose();
                           // setSelectedPlaylist(e.playlist_id);
                         }}
                       >
-                        {e.playlist_name}
+                        {e.title}
                       </MenuItem>
                     ))}
               </Menu>
@@ -345,7 +342,7 @@ export default function MusicPage(props: any) {
             {/* 재생목록 리스트 */}
             {isLoading
               ? 'loading'
-              : data.tracks.content.map((track: any) => (
+              : data.content.map((track: any) => (
                   <li
                     key={track.id}
                     className="flex w-full flex-row space-x-4 self-start p-2 hover:rounded-md hover:bg-[#040404] hover:bg-opacity-30"


### PR DESCRIPTION
### PR Type

<!— Please check the one that applies to this PR using "[x]" —>

- [x] Feat(기능 추가)
- [ ] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

---

### Summary


---

### Description

재생 목록 조회 API에 오류가 있어 수정했습니다.

<img width="1726" alt="image" src="https://github.com/DreamVault-2024/dreamvalut-frontend/assets/133188752/90d83a1a-5c5c-4a00-a07c-f649a4f0f555">

실제 서버 API를 가져오긴 했는데 데이터 페이지네이션은 하지 않았고 임시로 하드코딩해 두었습니다. 나중에 따로 issue를 만들어 적용할 예정입니다.

그리고 마찬가지로 재생목록을 불러오는것도 다음 이슈에서 한꺼번에 할 예정이라 임시 구현만 해 두었습니다.

---

### Issue Number
53