### PR TITLE
[design] 메인 페이지 반응형&적응형 디자인 적용

### DIFF
--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -197,7 +197,7 @@ export async function fetchSystemPlaylist(pageIndex: number) {
   try {
     const accessToken = await getCookie('accessToken');
     const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_URL}/playlists?type=curated&page=${pageIndex}`,
+      `${process.env.NEXT_PUBLIC_API_URL}/playlists?type=curated&page=${pageIndex}&size=12`,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -30,7 +30,7 @@ export async function fetchTags(pageIndex: number) {
   try {
     const accessToken = await getCookie('accessToken');
     const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_URL}/tags/list?page=${pageIndex}`,
+      `${process.env.NEXT_PUBLIC_API_URL}/tags/list?page=${pageIndex}&size=12`,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -153,11 +153,11 @@ export async function getRecentList(page: number, size: number) {
 }
 
 // 장르별 플레이리스트 목록 가져오기
-export async function fetchGenrePlaylist(pageIndex: number) {
+export async function fetchGenrePlaylist() {
   try {
     const accessToken = await getCookie('accessToken');
     const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_URL}/genres?page=${pageIndex}`,
+      `${process.env.NEXT_PUBLIC_API_URL}/genres?page=0&size=100`,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/app/components/AlbumCover/AlbumCoverSystem.tsx
+++ b/src/app/components/AlbumCover/AlbumCoverSystem.tsx
@@ -1,9 +1,11 @@
+/* eslint-disable max-len */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable @next/next/no-img-element */
 import React, { useState, useEffect } from 'react';
 import { albumCoverSystemProps } from '@/types/albumCover.ts';
 import Link from 'next/link';
 import Image from 'next/image';
+import { matchMedia } from '@/util/matchMedia.ts';
 
 function AlbumCoverSystem({
   image,
@@ -12,6 +14,8 @@ function AlbumCoverSystem({
   curation,
 }: albumCoverSystemProps) {
   const [albumRandomColor, setAlbumRandomColor] = useState('');
+  const [albumSize, setAlbumSize] = useState<number>(40); // 앨범 커버 크기
+  matchMedia();
 
   useEffect(() => {
     // 컴포넌트가 처음 렌더링될 때 한 번만 랜덤한 색상을 선택
@@ -28,40 +32,58 @@ function AlbumCoverSystem({
     const randomIndex = Math.floor(Math.random() * randomAlbumColorList.length);
     setAlbumRandomColor(randomAlbumColorList[randomIndex]);
   }, []); // 빈 배열을 넣어서 처음 렌더링 시에만 실행되도록 함
-  // console.log('image : ', image);
+
+  useEffect(() => {
+    if (matchMedia() === '2xl') {
+      setAlbumSize(40);
+    } else if (matchMedia() === 'xl') {
+      setAlbumSize(32);
+    } else {
+      setAlbumSize(28);
+    }
+  }, []);
+
+  window.addEventListener('resize', () => {
+    if (matchMedia() === '2xl') {
+      setAlbumSize(40);
+    } else if (matchMedia() === 'xl') {
+      setAlbumSize(32);
+    } else {
+      setAlbumSize(28);
+    }
+  });
+
   return (
     <>
       <Link
         href={`/${curation === 'tag' ? 'tag' : 'playlist'}/${Id}`}
-        className="hover-bg-opacity flex h-72 cursor-pointer flex-col items-center justify-center px-4"
+        className="hover-bg-opacity flex h-32 cursor-pointer flex-col items-center justify-center px-4 xl:h-40 2xl:h-48"
       >
-        <figure className="relative h-40 w-40 rounded-lg">
+        <figure className={`relative h-${albumSize} w-${albumSize} rounded-lg`}>
           <Image
-            src={
-              image === 'default'
-                ? 'https://i.ibb.co/26Bt8jw/Dream-Vault-Logo-BGO.png'
-                : image
-            }
+            src={image}
             alt="Album cover"
             className="rounded-lg"
             layout="fill"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
             objectFit="cover"
           />
         </figure>
 
         <div
-          className={`z-10 -mt-40 h-40 w-40 rounded-lg ${albumRandomColor} opacity-50`}
-        />
-        <p
-          className={
-            'drop-shadow-text z-20 -mt-40 flex h-40 w-40 flex-wrap items-center justify-center text-xl font-bold'
-          }
+          className={`z-10 -mt-${albumSize} h-${albumSize} w-${albumSize} rounded-lg ${albumRandomColor} bg-opacity-50`}
+        >
+          <p
+            className={`drop-shadow-text z-20 flex h-${albumSize} w-${albumSize} text-md z-20 flex-wrap items-center justify-center font-bold xl:text-lg`}
+          >
+            {title}
+          </p>
+        </div>
+        {/* <p
+          className={`z-20 flex h-16 w-${albumSize} text-md items-start justify-start overflow-hidden text-ellipsis whitespace-nowrap pt-4 text-white xl:text-lg`}
         >
           {title}
-        </p>
-        <p className="z-20 flex h-16 w-40 items-start justify-center pt-4 text-xl text-white">
-          {title}
-        </p>
+        </p> */}
       </Link>
     </>
   );

--- a/src/app/components/AlbumCover/AlbumCoverSystem.tsx
+++ b/src/app/components/AlbumCover/AlbumCoverSystem.tsx
@@ -5,7 +5,6 @@ import React, { useState, useEffect } from 'react';
 import { albumCoverSystemProps } from '@/types/albumCover.ts';
 import Link from 'next/link';
 import Image from 'next/image';
-import { matchMedia } from '@/util/matchMedia.ts';
 
 function AlbumCoverSystem({
   image,
@@ -14,8 +13,6 @@ function AlbumCoverSystem({
   curation,
 }: albumCoverSystemProps) {
   const [albumRandomColor, setAlbumRandomColor] = useState('');
-  const [albumSize, setAlbumSize] = useState<number>(40); // 앨범 커버 크기
-  matchMedia();
 
   useEffect(() => {
     // 컴포넌트가 처음 렌더링될 때 한 번만 랜덤한 색상을 선택
@@ -33,33 +30,17 @@ function AlbumCoverSystem({
     setAlbumRandomColor(randomAlbumColorList[randomIndex]);
   }, []); // 빈 배열을 넣어서 처음 렌더링 시에만 실행되도록 함
 
-  useEffect(() => {
-    if (matchMedia() === '2xl') {
-      setAlbumSize(40);
-    } else if (matchMedia() === 'xl') {
-      setAlbumSize(32);
-    } else {
-      setAlbumSize(28);
-    }
-  }, []);
-
-  window.addEventListener('resize', () => {
-    if (matchMedia() === '2xl') {
-      setAlbumSize(40);
-    } else if (matchMedia() === 'xl') {
-      setAlbumSize(32);
-    } else {
-      setAlbumSize(28);
-    }
-  });
-
   return (
     <>
       <Link
         href={`/${curation === 'tag' ? 'tag' : 'playlist'}/${Id}`}
-        className="hover-bg-opacity flex h-32 cursor-pointer flex-col items-center justify-center px-4 xl:h-40 2xl:h-48"
+        className="hover-bg-opacity flex h-36 cursor-pointer flex-col items-center justify-center px-4 xl:h-40 2xl:h-44"
       >
-        <figure className={`relative h-${albumSize} w-${albumSize} rounded-lg`}>
+        <figure
+          className={
+            'relative h-32 w-32 rounded-lg xl:h-36 xl:w-36 2xl:h-40 2xl:w-40'
+          }
+        >
           <Image
             src={image}
             alt="Album cover"
@@ -71,19 +52,16 @@ function AlbumCoverSystem({
         </figure>
 
         <div
-          className={`z-10 -mt-28 xl:-mt-32 2xl:-mt-40 h-${albumSize} w-${albumSize} rounded-lg ${albumRandomColor} flex flex-wrap items-center justify-center bg-opacity-50 px-2 font-bold text-white xl:text-lg`}
+          className={`z-10 -mt-32 h-32 w-32 rounded-lg xl:-mt-36 xl:h-36 xl:w-36 2xl:-mt-40 2xl:h-40 2xl:w-40 ${albumRandomColor} flex flex-wrap items-center justify-center bg-opacity-50 px-2 font-bold text-white xl:text-lg`}
         >
           <p
-            className={`drop-shadow-text z-20 flex h-${albumSize} w-${albumSize} text-md z-20 flex-wrap items-center justify-center font-bold xl:text-lg`}
+            className={
+              'drop-shadow-text text-md z-20 flex h-32 w-32 flex-wrap items-center justify-center font-bold xl:h-36 xl:w-36 xl:text-lg 2xl:h-40 2xl:w-40'
+            }
           >
             {title}
           </p>
         </div>
-        {/* <p
-          className={`z-20 flex h-16 w-${albumSize} text-md items-start justify-start overflow-hidden text-ellipsis whitespace-nowrap pt-4 text-white xl:text-lg`}
-        >
-          {title}
-        </p> */}
       </Link>
     </>
   );

--- a/src/app/components/AlbumCover/AlbumCoverSystem.tsx
+++ b/src/app/components/AlbumCover/AlbumCoverSystem.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { albumCoverSystemProps } from '@/types/albumCover.ts';
 import Link from 'next/link';
+import Image from 'next/image';
 
 function AlbumCoverSystem({
   image,
@@ -27,32 +28,38 @@ function AlbumCoverSystem({
     const randomIndex = Math.floor(Math.random() * randomAlbumColorList.length);
     setAlbumRandomColor(randomAlbumColorList[randomIndex]);
   }, []); // 빈 배열을 넣어서 처음 렌더링 시에만 실행되도록 함
-
+  // console.log('image : ', image);
   return (
     <>
       <Link
         href={`/${curation === 'tag' ? 'tag' : 'playlist'}/${Id}`}
-        className="hover-bg-opacity m-4 flex h-72 w-56 cursor-pointer flex-col items-center justify-center p-4"
+        className="hover-bg-opacity flex h-72 cursor-pointer flex-col items-center justify-center px-4"
       >
-        {/* <Image
-        src={image}
-        alt="Album cover"
-        className="rounded-lg"
-        width={192}
-        height={192}
-      /> */}
-        <img src={image} alt="Album cover" className="h-48 w-48 rounded-lg" />
+        <figure className="relative h-40 w-40 rounded-lg">
+          <Image
+            src={
+              image === 'default'
+                ? 'https://i.ibb.co/26Bt8jw/Dream-Vault-Logo-BGO.png'
+                : image
+            }
+            alt="Album cover"
+            className="rounded-lg"
+            layout="fill"
+            objectFit="cover"
+          />
+        </figure>
+
         <div
-          className={`z-10 -mt-48 h-48 w-48 rounded-lg ${albumRandomColor} opacity-50`}
+          className={`z-10 -mt-40 h-40 w-40 rounded-lg ${albumRandomColor} opacity-50`}
         />
         <p
           className={
-            'drop-shadow-text z-20 -mt-48 flex h-48 w-48 flex-wrap items-center justify-center p-4 text-xl font-bold'
+            'drop-shadow-text z-20 -mt-40 flex h-40 w-40 flex-wrap items-center justify-center text-xl font-bold'
           }
         >
           {title}
         </p>
-        <p className="z-20 flex h-16 w-48 items-start justify-center pt-4 text-xl text-white">
+        <p className="z-20 flex h-16 w-40 items-start justify-center pt-4 text-xl text-white">
           {title}
         </p>
       </Link>

--- a/src/app/components/AlbumCover/AlbumCoverSystem.tsx
+++ b/src/app/components/AlbumCover/AlbumCoverSystem.tsx
@@ -71,7 +71,7 @@ function AlbumCoverSystem({
         </figure>
 
         <div
-          className={`z-10 -mt-${albumSize} h-${albumSize} w-${albumSize} rounded-lg ${albumRandomColor} bg-opacity-50`}
+          className={`z-10 -mt-28 xl:-mt-32 2xl:-mt-40 h-${albumSize} w-${albumSize} rounded-lg ${albumRandomColor} flex flex-wrap items-center justify-center bg-opacity-50 px-2 font-bold text-white xl:text-lg`}
         >
           <p
             className={`drop-shadow-text z-20 flex h-${albumSize} w-${albumSize} text-md z-20 flex-wrap items-center justify-center font-bold xl:text-lg`}

--- a/src/app/components/AlbumCover/AlbumCoverUser.tsx
+++ b/src/app/components/AlbumCover/AlbumCoverUser.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable @next/next/no-img-element */
 import { albumCoverUserProps } from '@/types/albumCover.ts';
 import Link from 'next/link';
+import Image from 'next/image';
 
 function AlbumCoverUser({
   image1,
@@ -14,45 +15,38 @@ function AlbumCoverUser({
   return (
     <Link
       href={`playlist/${Id}`}
-      className="flex flex-col w-56 h-80 items-center justify-center m-4 cursor-pointer hover-bg-opacity pt-8 p-1"
+      className="hover-bg-opacity flex h-60 w-60 cursor-pointer flex-col items-center justify-center p-4 pt-10 xl:h-64 2xl:h-80"
     >
-      {/* <Image
-        src={image1}
-        alt="Album cover"
-        className="rounded-lg z-30"
-        width={192}
-        height={192}
-      />
-      <Image
-        src={image2}
-        alt="Album cover"
-        className="rounded-lg -mt-52 z-20"
-        width={176}
-        height={176}
-      />
-      <Image
-        src={image3}
-        alt="Album cover"
-        className="rounded-lg -mt-48 z-10"
-        width={160}
-        height={160}
-      /> */}
-      <img
-        src={image1}
-        alt="Album cover"
-        className="h-48 w-48 rounded-lg z-30"
-      />
-      <img
-        src={image2}
-        alt="Album cover"
-        className="h-44 w-44 rounded-lg -mt-52 z-20"
-      />
-      <img
-        src={image3}
-        alt="Album cover"
-        className="h-40 w-40 rounded-lg -mt-48 z-10"
-      />
-      <p className="text-lg h-16 text-white text-center mt-20">{title}</p>
+      <figure className="relative z-30 h-32 w-32 rounded-lg xl:h-36 xl:w-36 2xl:h-40 2xl:w-40">
+        <Image
+          src={image1}
+          alt="Album cover"
+          className="z-30 rounded-lg"
+          layout="fill"
+          objectFit="cover"
+        />
+      </figure>
+      <figure className="relative z-20 -mt-32 h-28 w-28 rounded-lg xl:-mt-36 xl:h-32 xl:w-32 2xl:-mt-44 2xl:h-36 2xl:w-36">
+        <Image
+          src={image2}
+          alt="Album cover"
+          className="z-20 rounded-lg"
+          layout="fill"
+          objectFit="cover"
+        />
+      </figure>
+      <figure className="relative z-10 -mt-28 h-24 w-24 rounded-lg xl:-mt-32 xl:h-28 xl:w-28 2xl:-mt-40 2xl:h-32 2xl:w-32">
+        <Image
+          src={image3}
+          alt="Album cover"
+          className="z-10 rounded-lg"
+          layout="fill"
+          objectFit="cover"
+        />
+      </figure>
+      <p className="text-md mt-16 h-16 text-center font-bold text-white xl:mt-20 xl:text-lg">
+        {title}
+      </p>
     </Link>
   );
 }

--- a/src/app/components/NavBar/NavigationBar.tsx
+++ b/src/app/components/NavBar/NavigationBar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable @next/next/no-img-element */
 
@@ -50,15 +51,15 @@ export function SearchAppBar() {
         InputProps={{
           startAdornment: (
             <Link href={`/search/${keyward}`}>
-              <IconButton className="-ml-1 p-0">
+              <IconButton>
                 <InputAdornment position="start">
-                  <SearchIcon color="primary" className="w-[1.1rem]" />
+                  <SearchIcon color="primary" className="-ml-3 w-[1.1rem]" />
                 </InputAdornment>
               </IconButton>
             </Link>
           ),
           className:
-            'text-white bg-[#353535] h-[5vh] text-xs sm:text-[10px] md:text-xs lg:text-sm mb-[3rem]',
+            'text-white bg-[#353535] justify-start h-10 text-xs lg:text-sm mb-1',
         }}
         variant="outlined"
         value={keyward}
@@ -75,7 +76,7 @@ export function ToggleSearchbar() {
   return (
     <Menu as="div" className="relative inline-block text-left">
       <div>
-        <MenuButton className="-ml-2 inline-flex w-full justify-center rounded-md bg-transparent px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm">
+        <MenuButton className="inline-flex w-full justify-center rounded-md bg-transparent px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm">
           <SearchIcon color="primary" />
         </MenuButton>
       </div>
@@ -105,84 +106,86 @@ function NavigationBar() {
 
   return (
     <ThemeProvider theme={theme}>
-      <div className="width5 fixed left-0 top-0 z-40 flex h-full w-[5rem] flex-col justify-start bg-zinc-900 p-4 text-white sm:w-[5rem] md:w-[8rem] lg:w-[12.5rem]">
-        <Link className="flex cursor-pointer flex-col" href={'/main'}>
+      <div className="flex h-full w-20 lg:w-60" />
+      <div className="fixed z-40 flex h-full w-20 flex-shrink-0 flex-grow flex-col bg-zinc-900 p-2 text-white lg:w-60 lg:justify-start lg:p-4">
+        <Link
+          className="flex w-full cursor-pointer flex-col items-center lg:items-start"
+          href={'/main'}
+        >
           <div className="mt-5 flex items-center">
             <img
               src="https://i.ibb.co/1GnSm8z/Dream-Vault-Png.png"
               alt="DreamVault-logo-img"
-              className="w-[10rem] sm:w-[10rem] md:w-1/3 lg:w-1/3"
+              className="w-8"
             />
-            <div className="relative">
-              <h2 className="text-1xl hide-text md:text-1xl p-3 font-bold sm:text-[10px] lg:text-[18px]">
+            <div className="relative flex items-center justify-start">
+              <h1 className="hide-text md:text-1xl p-2 text-xl font-bold sm:text-[10px] lg:text-[18px]">
                 DreamVault
-              </h2>
-
-              <h6 className="hide-text absolute left-2 top-5 -translate-y-full p-1 text-xs sm:text-[8px] lg:text-[10px]">
+              </h1>
+              <h6 className="hide-text -mt-4 flex text-xs sm:text-[8px] lg:text-[10px]">
                 Beta
               </h6>
             </div>
           </div>
         </Link>
-        <div className="mt-12 flex h-full flex-col">
-          <div className="hidden sm:hidden md:block lg:block">
+        <div className="mt-6 flex h-full w-full flex-col">
+          <div className="hidden w-full lg:mb-8 lg:block">
             <span className="hide-text">
               <SearchAppBar />
             </span>
           </div>
-          <div className="mb-10 block sm:block md:hidden lg:hidden">
+          <div className="hover-bg-opacity flex w-full cursor-pointer flex-col items-center justify-center rounded-lg py-1 lg:hidden">
             <ToggleSearchbar />
+            <p className="text-[0.5rem] lg:hidden">검색</p>
           </div>
           {/* 일부 화면 크기에서 검색 아이콘 사라지는것 방지 */}
           <div className="show-searchbar mb-10 hidden">
             <ToggleSearchbar />
           </div>
-          <Link href={'/main'}>
-            <div className="hover-bg-opacity mb-5 flex cursor-pointer items-center rounded-lg">
-              <HomeIcon color="primary" />
-              <button className="hidden p-2 sm:block sm:text-[10px] md:block lg:text-sm">
-                <span className="hide-text">홈</span>
-              </button>
-            </div>
+          <Link
+            href={'/main'}
+            className="hover-bg-opacity flex w-full cursor-pointer flex-col items-center justify-center rounded-lg py-1 lg:flex-row lg:justify-start lg:p-2"
+          >
+            <HomeIcon color="primary" />
+            <p className="pt-2 text-[0.5rem] lg:ml-4 lg:pt-0 lg:text-sm">홈</p>
           </Link>
 
           <Link
-            className="hover-bg-opacity mb-5 flex cursor-pointer items-center rounded-lg"
+            className="hover-bg-opacity flex w-full cursor-pointer flex-col items-center justify-center rounded-lg py-1 lg:flex-row lg:justify-start lg:p-2"
             href={'/playlist'}
           >
             <PlaylistPlayIcon color="primary" />
-            <button className="hidden p-2 sm:block sm:text-[10px] md:block lg:text-sm">
-              <span className="hide-text">플레이리스트</span>
-            </button>
+            <p className="pt-2 text-[0.5rem] lg:ml-4 lg:pt-0 lg:text-sm">
+              플레이리스트
+            </p>
           </Link>
 
-          <Link href={'/post_music'}>
-            <div className="hover-bg-opacity mb-5 flex cursor-pointer items-center rounded-lg">
-              <EditNoteIcon color="primary" />
-              <button className="hidden p-2 sm:block sm:text-[8px] md:block lg:text-sm">
-                <span className="hide-text">나만의 음악 등록</span>
-              </button>
-            </div>
+          <Link
+            href={'/post_music'}
+            className="hover-bg-opacity flex w-full cursor-pointer flex-col items-center justify-center rounded-lg py-1 lg:flex-row lg:justify-start lg:p-2"
+          >
+            <EditNoteIcon color="primary" />
+            <p className="pt-2 text-[0.5rem] lg:ml-4 lg:pt-0 lg:text-sm">
+              음악 등록
+            </p>
           </Link>
 
-          <Link href={'/mypage'}>
-            <div className="hover-bg-opacity mb-5 flex cursor-pointer items-center rounded-lg">
-              <PersonIcon color="primary" />
-              <button className="hidden p-2 sm:block sm:text-[10px] md:block lg:text-sm">
-                <span className="hide-text">프로필</span>
-              </button>
-            </div>
+          <Link
+            href={'/mypage'}
+            className="hover-bg-opacity flex w-full cursor-pointer flex-col items-center justify-center rounded-lg py-1 lg:flex-row lg:justify-start lg:p-2"
+          >
+            <PersonIcon color="primary" />
+            <p className="pt-2 text-[0.5rem] lg:ml-4 lg:pt-0 lg:text-sm">
+              프로필
+            </p>
           </Link>
         </div>
 
         <div className="my-4 flex flex-col">
-          <div className="hover-bg-opacity flex items-center rounded-lg text-sm">
+          <div className="hover-bg-opacity m-1 flex items-center rounded-lg text-sm">
             <MeetingRoomIcon color="primary" />
-            <button
-              className="hidden p-2 sm:block sm:text-[10px] md:block lg:text-sm"
-              onClick={LogOut}
-            >
-              <span className="hide-text">로그아웃</span>
+            <button className="hidden p-2 sm:block lg:text-sm" onClick={LogOut}>
+              <p className="hide-text">로그아웃</p>
             </button>
           </div>
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
         />
         <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.js"></script>
       </head>
-      <body className={inter.className}>
+      <body className={`${inter.className} flex w-full flex-row`}>
         <link
           rel="icon"
           href="https://i.ibb.co/1GnSm8z/Dream-Vault-Png.png"
@@ -42,10 +42,10 @@ export default function RootLayout({
         />
         <QueryProviders>
           <SharedAudioProvider>
-            {children}
+            <NavigationBar />
+            <div className="main-content">{children}</div>
             <MusicBar trackId={trackId} />
           </SharedAudioProvider>
-          <NavigationBar />
         </QueryProviders>
       </body>
     </html>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -13,7 +13,7 @@ import Image from 'next/image';
 // 클라이언트 코드에서 실제 서버로 POST 요청을 보내는 방식
 const LogIn = () => (
   <>
-    <div className="fade-in-box flex h-screen flex-col items-center justify-center">
+    <div className="fade-in-box flex h-screen w-screen flex-col items-center justify-center">
       <img
         src="https://i.ibb.co/1GnSm8z/Dream-Vault-Png.png"
         alt="DreamVault-logo-img"

--- a/src/app/main/AllPlayList.tsx
+++ b/src/app/main/AllPlayList.tsx
@@ -33,7 +33,7 @@ function AllPlayListComponent() {
   if (isLoading) return <div>Loading...</div>;
   return (
     <ThemeProvider theme={theme}>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
@@ -62,7 +62,7 @@ function AllPlayListComponent() {
           />
         ))}
       </div>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/main/AllPlayList.tsx
+++ b/src/app/main/AllPlayList.tsx
@@ -33,7 +33,7 @@ function AllPlayListComponent() {
   if (isLoading) return <div>Loading...</div>;
   return (
     <ThemeProvider theme={theme}>
-      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
@@ -62,7 +62,7 @@ function AllPlayListComponent() {
           />
         ))}
       </div>
-      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/main/AllPlayList.tsx
+++ b/src/app/main/AllPlayList.tsx
@@ -1,28 +1,71 @@
+/* eslint-disable function-paren-newline */
+/* eslint-disable implicit-arrow-linebreak */
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable consistent-return */
 /* eslint-disable no-unused-vars */
 
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { IconButton } from '@mui/material';
 import BackIcon from '@mui/icons-material/ArrowBackIosNew';
 import ForwardIcon from '@mui/icons-material/ArrowForwardIos';
 import { ThemeProvider } from '@emotion/react';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getSlideContentStyle } from '@/app/styles/slide.ts';
 import AlbumCoverUser from '../components/AlbumCover/AlbumCoverUser.tsx';
 import theme from '../styles/theme.ts';
 import { fetchAllPlaylist } from '../../api/playlist.ts';
 
 function AllPlayListComponent() {
   const [pageIndex, setPageIndex] = useState(0); // 인기 음악 페이지 인덱스
-  const { isLoading, data } = useQuery({
-    queryKey: ['All Playlist Data', pageIndex],
-    queryFn: () => fetchAllPlaylist(pageIndex),
+  const [isVisible, setIsVisible] = useState(true);
+  const divRef = useRef(null);
+
+  const { data, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['All Playlist Data'],
+    queryFn: ({ pageParam }) => fetchAllPlaylist(pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.pageable.page_size - 1 > pageIndex) {
+        return pageIndex + 1;
+      }
+    },
   });
 
+  useEffect(() => {
+    fetchNextPage();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(false);
+          } else {
+            setIsVisible(true);
+          }
+        });
+      },
+      {
+        threshold: 0.1, // 10% 가시성을 기준으로 설정
+      },
+    );
+
+    if (divRef.current) {
+      observer.observe(divRef.current);
+    }
+
+    return () => {
+      if (divRef.current) {
+        observer.unobserve(divRef.current);
+      }
+    };
+  }, [divRef.current]);
+
   const handleForwardClick = () => {
-    if (data.pageable.page_size - 1 > pageIndex) {
+    if (isVisible) {
       setPageIndex(pageIndex + 1);
-    } // 이때 4는 한번에 보여지는 인기음악의 개수
+      fetchNextPage();
+    }
   };
 
   const handleBackwardClick = () => {
@@ -30,7 +73,7 @@ function AllPlayListComponent() {
       setPageIndex(pageIndex - 1);
     }
   };
-  if (isLoading) return <div>Loading...</div>;
+
   return (
     <ThemeProvider theme={theme}>
       <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
@@ -38,29 +81,35 @@ function AllPlayListComponent() {
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
       </div>
-      <div className="flex h-full w-11/12 flex-row items-center justify-start">
-        {data.content.map((content: any, index: number) => (
-          <AlbumCoverUser
-            key={index}
-            image1={
-              content.tracks[0] === undefined
-                ? null
-                : content.tracks[0].thumbnail_image
-            }
-            image2={
-              content.tracks[1] === undefined
-                ? null
-                : content.tracks[1].thumbnail_image
-            }
-            image3={
-              content.tracks[2] === undefined
-                ? null
-                : content.tracks[2].thumbnail_image
-            }
-            title={content.playlist_name}
-            Id={content.playlist_id}
-          />
-        ))}
+      <div
+        className="flex h-full w-11/12 flex-row items-center justify-start"
+        style={getSlideContentStyle(pageIndex, 3)}
+      >
+        {data?.pages.map((page: any) =>
+          page?.content.map((content: any, index: any) => (
+            <AlbumCoverUser
+              key={index}
+              image1={
+                content.tracks[0] === undefined
+                  ? null
+                  : content.tracks[0].thumbnail_image
+              }
+              image2={
+                content.tracks[1] === undefined
+                  ? null
+                  : content.tracks[1].thumbnail_image
+              }
+              image3={
+                content.tracks[2] === undefined
+                  ? null
+                  : content.tracks[2].thumbnail_image
+              }
+              title={content.playlist_name}
+              Id={content.playlist_id}
+            />
+          )),
+        )}
+        <div ref={divRef} />
       </div>
       <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>

--- a/src/app/main/Chart.tsx
+++ b/src/app/main/Chart.tsx
@@ -23,11 +23,11 @@ function MusicElement({ ranking, thumnailImage, title, trackId }: chartProps) {
       className="hover-bg-opacity my-1 flex h-1/4 w-1/2 cursor-pointer flex-row items-center justify-start lg:w-1/2 xl:w-1/3 2xl:w-1/4"
     >
       {/* 순위 */}
-      <p className="drop-shadow-text z-10 -ml-4 -mr-4 mt-6 w-16 text-right text-4xl">
+      <p className="drop-shadow-text z-10 -ml-3 -mr-3 mt-6 w-16 text-right text-3xl xl:-ml-4 xl:-mr-4 xl:text-4xl ">
         {ranking}
       </p>
       {/* 앨범 커버 */}
-      <figure className="relative flex h-16 w-16">
+      <figure className="relative flex h-12 w-12 xl:h-14 xl:w-14 2xl:h-16 2xl:w-16">
         <Image
           alt="Album Cover"
           src={thumnailImage}

--- a/src/app/main/Chart.tsx
+++ b/src/app/main/Chart.tsx
@@ -5,12 +5,13 @@
 import { IconButton } from '@mui/material';
 import BackIcon from '@mui/icons-material/ArrowBackIosNew';
 import ForwardIcon from '@mui/icons-material/ArrowForwardIos';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { ThemeProvider } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
 import { getSlideContentStyle } from '@/app/styles/slide.ts';
 import Link from 'next/link';
+import { matchMedia } from '@/util/matchMedia.ts';
 import { chartProps } from '../../types/chart.ts';
 import { fetchChartData } from '../../api/chart.ts';
 import theme from '../styles/theme.ts';
@@ -19,18 +20,25 @@ function MusicElement({ ranking, thumnailImage, title, trackId }: chartProps) {
   return (
     <Link
       href={`/track/${trackId}`}
-      className="hover-bg-opacity m-2 flex h-1/4 w-[24%] cursor-pointer flex-row items-center justify-start"
+      className="hover-bg-opacity my-1 flex h-1/4 w-1/2 cursor-pointer flex-row items-center justify-start lg:w-1/2 xl:w-1/3 2xl:w-1/4"
     >
       {/* 순위 */}
-      <p className="drop-shadow-text z-10 -mr-4 mt-6 w-16 text-right text-4xl">
+      <p className="drop-shadow-text z-10 -ml-4 -mr-4 mt-6 w-16 text-right text-4xl">
         {ranking}
       </p>
       {/* 앨범 커버 */}
-      <Image width={64} height={64} alt="Album Cover" src={thumnailImage} />
+      <figure className="relative flex h-16 w-16">
+        <Image
+          alt="Album Cover"
+          src={thumnailImage}
+          layout="fill"
+          objectFit="cover"
+        />
+      </figure>
 
       {/* 음악 정보 */}
-      <div className="ml-4 flex flex-col justify-center">
-        <p className="z-10 w-full text-xl">{title}</p>
+      <div className="ml-2 flex flex-col justify-center">
+        <p className="text-md z-10 flex w-full flex-wrap p-2">{title}</p>
       </div>
     </Link>
   );
@@ -41,13 +49,36 @@ function Chart() {
   const renderSize = 60;
   const musicList = [];
 
+  matchMedia();
+  const [chartSize, setChartSize] = useState<number>(2); // 차트에 표시할 음악 개수
+
+  useEffect(() => {
+    if (matchMedia() === '2xl') {
+      setChartSize(4);
+    } else if (matchMedia() === 'xl') {
+      setChartSize(3);
+    } else {
+      setChartSize(2);
+    }
+  }, []);
+
+  window.addEventListener('resize', () => {
+    if (matchMedia() === '2xl') {
+      setChartSize(4);
+    } else if (matchMedia() === 'xl') {
+      setChartSize(3);
+    } else {
+      setChartSize(2);
+    }
+  });
+
   const { isLoading, data } = useQuery({
     queryKey: ['Chart Music Data'],
     queryFn: () => fetchChartData(0, renderSize), // 하드코딩, 추후 수정 필요
   });
   if (data) {
     // 데이터가 존재할 때만 PopularMusic 컴포넌트 생성
-    for (let i = 0; i < 60; i += 1) {
+    for (let i = 0; i < renderSize; i += 1) {
       if (data.content[i]) {
         // 데이터가 존재하는 경우에만 생성
         musicList.push(
@@ -64,9 +95,9 @@ function Chart() {
   }
 
   const handleForwardClick = () => {
-    if (Math.ceil(data.content.length / 3) - 4 > pageIndex) {
+    if (Math.ceil(data.content.length / 3) - chartSize > pageIndex) {
       setPageIndex(pageIndex + 1);
-    } // 이때 4는 한번에 보여지는 인기음악의 개수
+    } // 이때 chartSize는 한번에 보여지는 인기음악의 개수
   };
 
   const handleBackwardClick = () => {
@@ -86,7 +117,7 @@ function Chart() {
         className={
           'slide-content flex h-full w-5/6 flex-col flex-wrap items-start justify-center'
         }
-        style={getSlideContentStyle(pageIndex, 4)}
+        style={getSlideContentStyle(pageIndex, chartSize)}
       >
         {isLoading ? <div>Loading...</div> : musicList}
       </div>

--- a/src/app/main/Genre.tsx
+++ b/src/app/main/Genre.tsx
@@ -46,11 +46,14 @@ function GenreMusic({
   musicTitle1,
   musicTitle2,
   musicTitle3,
+  id1,
+  id2,
+  id3,
 }: GenreMusicProps) {
   const musicList = [
-    { image: musicImage1, title: musicTitle1 },
-    { image: musicImage2, title: musicTitle2 },
-    { image: musicImage3, title: musicTitle3 },
+    { image: musicImage1, title: musicTitle1, id: id1 },
+    { image: musicImage2, title: musicTitle2, id: id2 },
+    { image: musicImage3, title: musicTitle3, id: id3 },
   ];
 
   return (
@@ -68,15 +71,16 @@ function GenreMusic({
 
       {/* 음악 정보 */}
       <div
-        className={`flex h-full w-full flex-col items-center justify-center rounded-b-xl bg-genre-${bgColor} mx-4`}
+        className={`flex h-full w-full flex-col items-center justify-center rounded-b-xl p-1 bg-genre-${bgColor} mx-4`}
       >
         {/* 음악 정보 */}
         {musicList.map((music, index) => (
-          <div
+          <Link
+            href={`/track/${music.id}`}
             key={index}
             className="hover-bg-opacity flex w-11/12 cursor-pointer flex-row items-center justify-start rounded-3xl p-1 hover:bg-opacity-90 xl:p-2"
           >
-            <figure className="relative m-2 flex h-10 w-10 xl:h-12 xl:w-12">
+            <figure className="relative m-2 flex h-10 w-10 xl:h-14 xl:w-14">
               <Image
                 src={music.image}
                 alt="Music cover"
@@ -88,7 +92,7 @@ function GenreMusic({
             <p className="flex w-3/5 flex-wrap text-sm font-bold text-black">
               {music.title}
             </p>
-          </div>
+          </Link>
         ))}
       </div>
     </div>
@@ -158,7 +162,7 @@ function Genre() {
   console.log('isVisible :', isVisible);
   return (
     <ThemeProvider theme={theme}>
-      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
@@ -172,7 +176,11 @@ function Genre() {
           (
             genreData: {
               genre_name: string;
-              tracks: { thumbnail_image: string; title: string }[];
+              tracks: {
+                thumbnail_image: string;
+                title: string;
+                track_id: number;
+              }[];
             },
             index: number,
           ) => (
@@ -187,13 +195,16 @@ function Genre() {
                 musicTitle1={genreData.tracks[0].title}
                 musicTitle2={genreData.tracks[1].title}
                 musicTitle3={genreData.tracks[2].title}
+                id1={genreData.tracks[0].track_id}
+                id2={genreData.tracks[1].track_id}
+                id3={genreData.tracks[2].track_id}
               />
             </div>
           ),
         )}
         <div ref={divRef} />
       </div>
-      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/main/Genre.tsx
+++ b/src/app/main/Genre.tsx
@@ -54,29 +54,29 @@ function GenreMusic({
   ];
 
   return (
-    <div className="m-4 flex w-96 flex-col items-center justify-center">
+    <div className="m-4 flex w-56 flex-col items-center justify-center xl:w-72">
       {/* 위에 단색 배경바 */}
       <Link
         href={`/genre/${bgColor / 100}`}
-        className={`flex h-20 w-full flex-row items-center rounded-t-2xl p-4 bg-nv-${bgColor}`}
+        className={`flex h-12 w-full flex-row items-center rounded-t-xl p-4 xl:h-16 bg-nv-${bgColor}`}
       >
-        {/* <p className="text-md m-4 w-full font-bold text-black">{genre}</p>
+        <p className="text-md mx-4 w-full font-bold text-black">{genre}</p>
         <IconButton>
-          <PlayCircleIcon style={{ fontSize: 50, opacity: 0.7 }} />
-        </IconButton> */}
+          <PlayCircleIcon style={{ fontSize: 30, opacity: 0.7 }} />
+        </IconButton>
       </Link>
 
       {/* 음악 정보 */}
       <div
-        className={`flex h-full w-full flex-col items-center justify-center rounded-b-2xl bg-genre-${bgColor} mx-4`}
+        className={`flex h-full w-full flex-col items-center justify-center rounded-b-xl bg-genre-${bgColor} mx-4`}
       >
         {/* 음악 정보 */}
-        {/* {musicList.map((music, index) => (
+        {musicList.map((music, index) => (
           <div
             key={index}
-            className="hover-bg-opacity flex h-16 w-11/12 cursor-pointer flex-row items-center justify-start rounded-3xl px-3 hover:bg-opacity-90"
+            className="hover-bg-opacity flex w-11/12 cursor-pointer flex-row items-center justify-start rounded-3xl p-1 hover:bg-opacity-90 xl:p-2"
           >
-            <figure className="relative m-2 flex h-12 w-12">
+            <figure className="relative m-2 flex h-10 w-10 xl:h-12 xl:w-12">
               <Image
                 src={music.image}
                 alt="Music cover"
@@ -85,9 +85,11 @@ function GenreMusic({
                 className="rounded-lg"
               />
             </figure>
-            <p className="flex flex-wrap text-sm text-black">{music.title}</p>
+            <p className="flex w-3/5 flex-wrap text-sm font-bold text-black">
+              {music.title}
+            </p>
           </div>
-        ))} */}
+        ))}
       </div>
     </div>
   );
@@ -124,12 +126,13 @@ function Genre() {
         observer.unobserve(divRef.current);
       }
     };
-  }, []);
+  }, [divRef.current]);
 
   const { isLoading, data } = useQuery({
-    queryKey: ['Genre Data'], // pageIndex를 queryKey에 추가
+    queryKey: ['Genre Data'],
     queryFn: fetchGenrePlaylist,
   });
+
   const handleForwardClick = () => {
     if (isVisible) {
       setPageIndex(pageIndex + 1);
@@ -173,7 +176,7 @@ function Genre() {
             },
             index: number,
           ) => (
-            <div className="flex h-96 w-80">
+            <div className="flex h-72 w-64 xl:h-80 xl:w-72">
               <GenreMusic
                 key={index}
                 genre={genreData.genre_name}
@@ -188,17 +191,7 @@ function Genre() {
             </div>
           ),
         )}
-        {/* <GenreMusic
-          genre={genreData.genre_name}
-          bgColor={randomGenreColor[index]}
-          musicImage1={genreData.tracks[0].thumbnail_image}
-          musicImage2={genreData.tracks[1].thumbnail_image}
-          musicImage3={genreData.tracks[2].thumbnail_image}
-          musicTitle1={genreData.tracks[0].title}
-          musicTitle2={genreData.tracks[1].title}
-          musicTitle3={genreData.tracks[2].title}
-        /> */}
-        <div ref={divRef} className="h-2 w-2 bg-blue-200" />
+        <div ref={divRef} />
       </div>
       <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>

--- a/src/app/main/Genre.tsx
+++ b/src/app/main/Genre.tsx
@@ -159,7 +159,7 @@ function Genre() {
   if (isLoading) {
     return <div>Loading...</div>;
   }
-  console.log('isVisible :', isVisible);
+
   return (
     <ThemeProvider theme={theme}>
       <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">

--- a/src/app/main/GenreColorArr.css
+++ b/src/app/main/GenreColorArr.css
@@ -87,7 +87,7 @@
 }
 
 .bg-nv-800 {
-  background-color: #f1eadd;
+  background-color: #e1f2ef;
 }
 
 .bg-nv-900 {

--- a/src/app/main/SystemPlaylist.tsx
+++ b/src/app/main/SystemPlaylist.tsx
@@ -77,7 +77,7 @@ function SystemPlaylist() {
 
   return (
     <ThemeProvider theme={theme}>
-      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
@@ -99,7 +99,7 @@ function SystemPlaylist() {
         )}
         <div ref={divRef} />
       </div>
-      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/main/SystemPlaylist.tsx
+++ b/src/app/main/SystemPlaylist.tsx
@@ -77,7 +77,7 @@ function SystemPlaylist() {
 
   return (
     <ThemeProvider theme={theme}>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
@@ -99,7 +99,7 @@ function SystemPlaylist() {
         )}
         <div ref={divRef} />
       </div>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/main/Tag.tsx
+++ b/src/app/main/Tag.tsx
@@ -77,7 +77,7 @@ function Tag() {
 
   return (
     <ThemeProvider theme={theme}>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
@@ -99,7 +99,7 @@ function Tag() {
         )}
         <div ref={divRef} />
       </div>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/main/Tag.tsx
+++ b/src/app/main/Tag.tsx
@@ -1,26 +1,70 @@
+/* eslint-disable function-paren-newline */
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable implicit-arrow-linebreak */
+/* eslint-disable no-shadow */
+
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { IconButton } from '@mui/material';
 import BackIcon from '@mui/icons-material/ArrowBackIosNew';
 import ForwardIcon from '@mui/icons-material/ArrowForwardIos';
 import { ThemeProvider } from '@emotion/react';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getSlideContentStyle } from '@/app/styles/slide.ts';
+import { fetchTags } from '@/api/playlist.ts';
 import AlbumCoverSystem from '../components/AlbumCover/AlbumCoverSystem.tsx';
 import theme from '../styles/theme.ts';
-import { fetchTags } from '../../api/playlist.ts';
 
 function Tag() {
   const [pageIndex, setPageIndex] = useState(0); // 인기 음악 페이지 인덱스
-  const musicList = [];
+  const [isVisible, setIsVisible] = useState(true);
+  const divRef = useRef(null);
 
-  const { isLoading, data } = useQuery({
-    queryKey: ['TagsData', pageIndex], // pageIndex를 queryKey에 추가
-    queryFn: () => fetchTags(pageIndex),
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(false);
+          } else {
+            setIsVisible(true);
+          }
+        });
+      },
+      {
+        threshold: 0.1, // 10% 가시성을 기준으로 설정
+      },
+    );
+
+    if (divRef.current) {
+      observer.observe(divRef.current);
+    }
+
+    return () => {
+      if (divRef.current) {
+        observer.unobserve(divRef.current);
+      }
+    };
+  }, []);
+
+  const { data, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['TagsData'], // pageIndex를 queryKey에 추가
+    queryFn: ({ pageParam = 0 }) => fetchTags(pageParam),
+    initialPageParam: 0,
+
+    getNextPageParam: (lastPage) => {
+      // if (!lastPage.last && !lastPage.empty) {
+      if (!lastPage.last) {
+        return lastPage.pageable.page_number + 1;
+      }
+      return undefined;
+    },
   });
 
   const handleForwardClick = () => {
-    if (data.total_pages - 1 > pageIndex) {
+    fetchNextPage();
+    if (isVisible) {
       setPageIndex(pageIndex + 1);
     }
   };
@@ -31,32 +75,6 @@ function Tag() {
     }
   };
 
-  if (data) {
-    // 데이터가 존재할 때만 PopularMusic 컴포넌트 생성
-    for (let i = 0; i < 6; i += 1) {
-      if (data.content[i]) {
-        // 데이터가 존재하는 경우에만 생성
-        musicList.push(
-          <div key={i}>
-            <AlbumCoverSystem
-              key={i}
-              image={data.content[i].tag_image}
-              title={data.content[i].tag_name}
-              Id={data.content[i].tag_id}
-              curation="tag"
-            />
-          </div>,
-        );
-      }
-    }
-  } else {
-    return <div>불러오기 실패</div>;
-  }
-
-  if (isLoading) {
-    return <div>Loading...</div>;
-  }
-
   return (
     <ThemeProvider theme={theme}>
       <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
@@ -64,8 +82,22 @@ function Tag() {
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
       </div>
-      <div className="flex h-full w-11/12 flex-row items-center justify-start">
-        {musicList}
+      <div
+        className="flex h-full w-11/12 flex-row items-center justify-start"
+        style={getSlideContentStyle(pageIndex, 3)}
+      >
+        {data?.pages.map((page: any, pageIndex) =>
+          page?.content.map((tag: any, index: any) => (
+            <AlbumCoverSystem
+              key={pageIndex * 6 + index}
+              image={tag.tag_image}
+              title={tag.tag_name}
+              Id={tag.tag_id}
+              curation="tag"
+            />
+          )),
+        )}
+        <div ref={divRef} />
       </div>
       <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>

--- a/src/app/main/Tag.tsx
+++ b/src/app/main/Tag.tsx
@@ -77,7 +77,7 @@ function Tag() {
 
   return (
     <ThemeProvider theme={theme}>
-      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
@@ -99,7 +99,7 @@ function Tag() {
         )}
         <div ref={divRef} />
       </div>
-      <div className="z-30 flex h-full w-1/12 flex-row items-center justify-center">
+      <div className="bg-zinc-650 z-30 flex h-full w-1/12 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -25,10 +25,9 @@ async function Page() {
 
         {/* 인기 태그 */}
         <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
-          {' '}
-          음악
+          태그 별 음악
         </h1>
-        <div className="bg-gray-650 flex h-48 w-full flex-row items-center justify-center overflow-hidden rounded-2xl xl:h-56 2xl:h-72">
+        <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
           <Tag />
         </div>
 
@@ -36,7 +35,7 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
           장르별 음악
         </h1>
-        <div className="bg-gray-650 flex h-[30rem] w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
+        <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
           <Genre />
         </div>
 
@@ -44,15 +43,15 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
           다른 유저가 선택한 플레이리스트
         </h1>
-        <div className="bg-gray-650 flex h-96 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
+        <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
           <AllPlaylistComponent />
         </div>
 
         {/* 구독한 플레이리스트 */}
         <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
-          DreamVault가 제공하는 플레이리스트
+          DreamVault 가 제공하는 플레이리스트
         </h1>
-        <div className="bg-gray-650 flex h-48 w-full flex-row items-center justify-center overflow-hidden rounded-2xl xl:h-56 2xl:h-72">
+        <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
           <SystemPlaylistComponent />
         </div>
       </div>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -3,11 +3,13 @@
 
 'use server';
 
-import Chart from './Chart.tsx';
+import dynamic from 'next/dynamic';
 import Tag from './Tag.tsx';
 import Genre from './Genre.tsx';
 import AllPlaylistComponent from './AllPlayList.tsx';
 import SystemPlaylistComponent from './SystemPlaylist.tsx';
+
+const Chart = dynamic(() => import('./Chart.tsx'), { ssr: false });
 
 // 메인 페이지 컴포넌트
 async function Page() {

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -27,7 +27,7 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           태그 별 음악
         </h1>
-        <div className="flex h-52 w-full flex-row items-center justify-center overflow-hidden">
+        <div className="flex h-36 w-full flex-row items-center justify-center overflow-hidden xl:h-40 2xl:h-44">
           <Tag />
         </div>
 
@@ -35,7 +35,7 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           장르별 음악
         </h1>
-        <div className="flex h-96 w-full flex-row items-center justify-center overflow-hidden">
+        <div className="flex h-72 w-full flex-row items-center justify-center overflow-hidden xl:h-96">
           <Genre />
         </div>
 
@@ -43,7 +43,7 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           다른 유저가 선택한 플레이리스트
         </h1>
-        <div className="flex h-80 w-full flex-row items-center justify-center overflow-hidden">
+        <div className="flex h-60 w-full flex-row items-center justify-center overflow-hidden xl:h-64 2xl:h-80">
           <AllPlaylistComponent />
         </div>
 
@@ -51,7 +51,7 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           DreamVault 가 제공하는 플레이리스트
         </h1>
-        <div className="flex h-52 w-full flex-row items-center justify-center overflow-hidden">
+        <div className="flex h-36 w-full flex-row items-center justify-center overflow-hidden xl:h-40 2xl:h-44">
           <SystemPlaylistComponent />
         </div>
       </div>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -16,7 +16,7 @@ async function Page() {
       {/* NavigationBar 제외 영역 */}
       <div className="h-full w-10/12 pr-8">
         {/* 인기 차트 */}
-        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           인기 차트
         </h1>
         <div className="bg-gray-650 flex h-64 w-full flex-row items-center justify-center overflow-hidden rounded-2xl xl:h-72 2xl:h-80 ">
@@ -24,7 +24,7 @@ async function Page() {
         </div>
 
         {/* 인기 태그 */}
-        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           태그 별 음악
         </h1>
         <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
@@ -32,7 +32,7 @@ async function Page() {
         </div>
 
         {/* 장르별 음악 */}
-        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           장르별 음악
         </h1>
         <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
@@ -40,7 +40,7 @@ async function Page() {
         </div>
 
         {/* 다른 유저가 선택한 플레이리스트 */}
-        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           다른 유저가 선택한 플레이리스트
         </h1>
         <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
@@ -48,7 +48,7 @@ async function Page() {
         </div>
 
         {/* 구독한 플레이리스트 */}
-        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           DreamVault 가 제공하는 플레이리스트
         </h1>
         <div className="flex w-full flex-row items-center justify-center overflow-hidden ">

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -27,7 +27,7 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           태그 별 음악
         </h1>
-        <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
+        <div className="flex h-52 w-full flex-row items-center justify-center overflow-hidden">
           <Tag />
         </div>
 
@@ -35,7 +35,7 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           장르별 음악
         </h1>
-        <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
+        <div className="flex h-96 w-full flex-row items-center justify-center overflow-hidden">
           <Genre />
         </div>
 
@@ -43,7 +43,7 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           다른 유저가 선택한 플레이리스트
         </h1>
-        <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
+        <div className="flex h-80 w-full flex-row items-center justify-center overflow-hidden">
           <AllPlaylistComponent />
         </div>
 
@@ -51,7 +51,7 @@ async function Page() {
         <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           DreamVault 가 제공하는 플레이리스트
         </h1>
-        <div className="flex w-full flex-row items-center justify-center overflow-hidden ">
+        <div className="flex h-52 w-full flex-row items-center justify-center overflow-hidden">
           <SystemPlaylistComponent />
         </div>
       </div>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -12,9 +12,9 @@ import SystemPlaylistComponent from './SystemPlaylist.tsx';
 // 메인 페이지 컴포넌트
 async function Page() {
   return (
-    <div className="flex h-full w-full flex-col items-end justify-end">
+    <div className="flex h-full w-full flex-grow flex-col items-end justify-end">
       {/* NavigationBar 제외 영역 */}
-      <div className="h-full w-10/12 pr-8">
+      <div className="flex h-full w-full flex-grow flex-col items-start justify-start px-4">
         {/* 인기 차트 */}
         <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           인기 차트

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -16,31 +16,42 @@ async function Page() {
       {/* NavigationBar 제외 영역 */}
       <div className="h-full w-10/12 pr-8">
         {/* 인기 차트 */}
-        <h1 className="">인기 차트</h1>
+        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+          인기 차트
+        </h1>
         <div className="bg-gray-650 flex h-64 w-full flex-row items-center justify-center overflow-hidden rounded-2xl xl:h-72 2xl:h-80 ">
           <Chart />
         </div>
 
         {/* 인기 태그 */}
-        <h1 className="">태그별 음악</h1>
+        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+          {' '}
+          음악
+        </h1>
         <div className="bg-gray-650 flex h-48 w-full flex-row items-center justify-center overflow-hidden rounded-2xl xl:h-56 2xl:h-72">
           <Tag />
         </div>
 
         {/* 장르별 음악 */}
-        <h1 className="">장르별 음악</h1>
+        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+          장르별 음악
+        </h1>
         <div className="bg-gray-650 flex h-[30rem] w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
           <Genre />
         </div>
 
         {/* 다른 유저가 선택한 플레이리스트 */}
-        <h1 className="">다른 유저가 선택한 플레이리스트</h1>
+        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+          다른 유저가 선택한 플레이리스트
+        </h1>
         <div className="bg-gray-650 flex h-96 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
           <AllPlaylistComponent />
         </div>
 
         {/* 구독한 플레이리스트 */}
-        <h1 className="">DreamVault가 제공하는 플레이리스트</h1>
+        <h1 className="mb-5 mt-14 text-2xl font-bold xl:text-3xl 2xl:text-4xl">
+          DreamVault가 제공하는 플레이리스트
+        </h1>
         <div className="bg-gray-650 flex h-48 w-full flex-row items-center justify-center overflow-hidden rounded-2xl xl:h-56 2xl:h-72">
           <SystemPlaylistComponent />
         </div>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -23,7 +23,7 @@ async function Page() {
 
         {/* 인기 태그 */}
         <h1 className="">태그별 음악</h1>
-        <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
+        <div className="bg-gray-650 flex h-48 w-full flex-row items-center justify-center overflow-hidden rounded-2xl xl:h-56 2xl:h-72">
           <Tag />
         </div>
 
@@ -41,7 +41,7 @@ async function Page() {
 
         {/* 구독한 플레이리스트 */}
         <h1 className="">DreamVault가 제공하는 플레이리스트</h1>
-        <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
+        <div className="bg-gray-650 flex h-48 w-full flex-row items-center justify-center overflow-hidden rounded-2xl xl:h-56 2xl:h-72">
           <SystemPlaylistComponent />
         </div>
       </div>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -17,7 +17,7 @@ async function Page() {
       <div className="h-full w-10/12 pr-8">
         {/* 인기 차트 */}
         <h1 className="">인기 차트</h1>
-        <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
+        <div className="bg-gray-650 flex h-64 w-full flex-row items-center justify-center overflow-hidden rounded-2xl xl:h-72 2xl:h-80 ">
           <Chart />
         </div>
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -107,7 +107,7 @@ export default function Mypage() {
 
   return (
     <ThemeProvider theme={theme}>
-      <div className="flex h-screen w-screen flex-col bg-[#1a1a1a] pl-[15%]">
+      <div className="flex h-screen w-full flex-col bg-[#1a1a1a]">
         <div className="flex h-fit w-full flex-row space-x-6 p-[2%]">
           {/* 내 계정 */}
           <div className="flex h-full w-[40%] flex-col">

--- a/src/app/playlist/page.tsx
+++ b/src/app/playlist/page.tsx
@@ -7,30 +7,35 @@ import FollowSystemPlaylist from './FollowSystemPlaylist.tsx';
 async function page() {
   return (
     <>
-      <div className="flex h-full w-full flex-col items-end justify-end overflow-hidden">
-        <div className="h-full w-10/12 pr-8">
-          {/* 내가 생성한 플레이리스트 */}
-          <h1 className="">내가 생성한 플레이리스트</h1>
-          <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
-            <MyPlaylistComponent />
-          </div>
-
-          {/* 팔로우한 플레이리스트 */}
-          <h1 className="">팔로우한 플레이리스트</h1>
-          <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
-            <FollowPlaylistComponent />
-          </div>
-
-          {/* 시스템 플레이리스트 */}
-          <h1 className="">구독한 플레이리스트</h1>
-          <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center rounded-2xl">
-            <FollowSystemPlaylist />
-          </div>
+      <div className="flex h-full w-full flex-col items-start justify-start overflow-hidden px-6">
+        {/* 내가 생성한 플레이리스트 */}
+        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
+          내가 생성한 플레이리스트
+        </h1>
+        <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
+          <MyPlaylistComponent />
         </div>
 
-        {/* 아래 여백 */}
-        <div className="h-40 w-full" />
+        {/* 팔로우한 플레이리스트 */}
+        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
+          {' '}
+          플레이리스트
+        </h1>
+        <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
+          <FollowPlaylistComponent />
+        </div>
+
+        {/* 시스템 플레이리스트 */}
+        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
+          구독한 플레이리스트
+        </h1>
+        <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center rounded-2xl">
+          <FollowSystemPlaylist />
+        </div>
       </div>
+
+      {/* 아래 여백 */}
+      <div className="h-40 w-full" />
     </>
   );
 }

--- a/src/app/search/[keyward]/page.tsx
+++ b/src/app/search/[keyward]/page.tsx
@@ -143,7 +143,7 @@ export default function SearchPage(props: any) {
     <ThemeProvider theme={theme}>
       <div className="h-fit min-h-screen">
         {/* NavBar 제외영역 */}
-        <div className="h-fit w-full pl-[15%]">
+        <div className="h-fit w-full">
           <div className="flex w-full flex-col gap-8 p-[3%]">
             {isLoading ? (
               <p className="w-fit text-xl">검색결과 가져오는 중 ...</p>

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -38,6 +38,10 @@ body {
   background-color: #333333;
 }
 
+.bg-zinc-650 {
+  background-color: #1a1a1a;
+}
+
 /* text-shadow 커스텀 지정 */
 .drop-shadow-text {
   text-shadow: 4px 2px 0.1px #777;

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -23,6 +23,15 @@
   background: #555; /* 호버 시 배경색 변경 */
 }
 
+.main-content {
+  width: calc(100% - 15rem); /* 15rem은 w-60에 해당하는 값 */
+}
+@media (max-width: 1024px) {
+  .main-content {
+    width: calc(100% - 5rem); /* 5rem은 w-20에 해당하는 값 */
+  }
+}
+
 body {
   background-color: #1a1a1a;
   color: white;
@@ -63,13 +72,6 @@ body {
   transform: scale(1.05);
   border-radius: 10px;
 }
-
-/* h1 {
-  font-size: 2.25rem;
-  margin-top: 3.25rem;
-  margin-bottom: 1.25rem;
-  font-weight: 700;
-} */
 
 /* 로그인페이지- 로그인 버튼들 효과 */
 .fade-in-box {
@@ -185,17 +187,12 @@ body {
   stroke: #441897;
 }
 
-@media (max-width: 780px) {
+@media (max-width: 1024px) {
   .hide-text {
     display: none;
   }
 }
 
-@media (min-width: 768px) and (max-width: 780px) {
-  .show-searchbar {
-    display: block;
-  }
-}
 /* 자동완성 배경색 제거 */
 input:-webkit-autofill {
   -webkit-box-shadow: 0 0 0 1000px #353535 inset;

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -60,12 +60,12 @@ body {
   border-radius: 10px;
 }
 
-h1 {
+/* h1 {
   font-size: 2.25rem;
   margin-top: 3.25rem;
   margin-bottom: 1.25rem;
   font-weight: 700;
-}
+} */
 
 /* 로그인페이지- 로그인 버튼들 효과 */
 .fade-in-box {

--- a/src/app/track/[trackId]/page.tsx
+++ b/src/app/track/[trackId]/page.tsx
@@ -178,7 +178,7 @@ export default function MusicPage(props: any) {
       </audio>
       {/* 블러배경 */}
       {!musicLoading && (
-        <div className="flex h-screen w-screen flex-row justify-around pl-[15%]">
+        <div className="flex h-screen w-screen flex-row justify-around">
           <img
             src={musicData.track_image}
             alt="1"

--- a/src/types/genre.ts
+++ b/src/types/genre.ts
@@ -22,4 +22,7 @@ export interface GenreMusicProps {
   musicTitle1: string;
   musicTitle2: string;
   musicTitle3: string;
+  id1: number;
+  id2: number;
+  id3: number;
 }

--- a/src/util/matchMedia.ts
+++ b/src/util/matchMedia.ts
@@ -9,25 +9,33 @@ const breakpoints = {
   sm: '640px',
 };
 
-const mediaQueryLists = {
-  '2xl': window.matchMedia(`(min-width: ${breakpoints['2xl']})`),
-  xl: window.matchMedia(
-    `(min-width: ${breakpoints.xl}) and (max-width: ${parseInt(breakpoints['2xl'], 10) - 1}px)`,
-  ),
-  lg: window.matchMedia(
-    `(min-width: ${breakpoints.lg}) and (max-width: ${parseInt(breakpoints.xl, 10) - 1}px)`,
-  ),
-  md: window.matchMedia(
-    `(min-width: ${breakpoints.md}) and (max-width: ${parseInt(breakpoints.lg, 10) - 1}px)`,
-  ),
-  sm: window.matchMedia(
-    `(min-width: ${breakpoints.sm}) and (max-width: ${parseInt(breakpoints.md, 10) - 1}px)`,
-  ),
-};
+let mediaQueryLists = {};
+
+if (typeof window !== 'undefined') {
+  mediaQueryLists = {
+    '2xl': window.matchMedia(`(min-width: ${breakpoints['2xl']})`),
+    xl: window.matchMedia(
+      `(min-width: ${breakpoints.xl}) and (max-width: ${parseInt(breakpoints['2xl'], 10) - 1}px)`,
+    ),
+    lg: window.matchMedia(
+      `(min-width: ${breakpoints.lg}) and (max-width: ${parseInt(breakpoints.xl, 10) - 1}px)`,
+    ),
+    md: window.matchMedia(
+      `(min-width: ${breakpoints.md}) and (max-width: ${parseInt(breakpoints.lg, 10) - 1}px)`,
+    ),
+    sm: window.matchMedia(
+      `(min-width: ${breakpoints.sm}) and (max-width: ${parseInt(breakpoints.md, 10) - 1}px)`,
+    ),
+  };
+}
 
 export function matchMedia() {
+  if (typeof window === 'undefined') {
+    return ''; // 서버 사이드 렌더링일 때는 빈 문자열 반환
+  }
+
   let result = '';
-  for (const [key, value] of Object.entries(mediaQueryLists)) {
+  for (const [key, value] of Object.entries<MediaQueryList>(mediaQueryLists)) {
     if (value.matches) {
       result = key;
     }

--- a/src/util/matchMedia.ts
+++ b/src/util/matchMedia.ts
@@ -1,0 +1,36 @@
+/* eslint-disable import/prefer-default-export */
+/* eslint-disable no-restricted-syntax */
+
+const breakpoints = {
+  '2xl': '1536px',
+  xl: '1280px',
+  lg: '1024px',
+  md: '768px',
+  sm: '640px',
+};
+
+const mediaQueryLists = {
+  '2xl': window.matchMedia(`(min-width: ${breakpoints['2xl']})`),
+  xl: window.matchMedia(
+    `(min-width: ${breakpoints.xl}) and (max-width: ${parseInt(breakpoints['2xl'], 10) - 1}px)`,
+  ),
+  lg: window.matchMedia(
+    `(min-width: ${breakpoints.lg}) and (max-width: ${parseInt(breakpoints.xl, 10) - 1}px)`,
+  ),
+  md: window.matchMedia(
+    `(min-width: ${breakpoints.md}) and (max-width: ${parseInt(breakpoints.lg, 10) - 1}px)`,
+  ),
+  sm: window.matchMedia(
+    `(min-width: ${breakpoints.sm}) and (max-width: ${parseInt(breakpoints.md, 10) - 1}px)`,
+  ),
+};
+
+export function matchMedia() {
+  let result = '';
+  for (const [key, value] of Object.entries(mediaQueryLists)) {
+    if (value.matches) {
+      result = key;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
### PR Type

<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [ ] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [x] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

---

### Summary
메인 페이지 반응형&적응형 디자인 적용

---

### Description
메인 페이지 반응형&적응형 디자인 적용했습니다.

https://github.com/DreamVault-2024/dreamvalut-frontend/assets/133188752/4428eed1-82d8-4add-84d1-c301177247ad

사용자의 화면사이즈가 2xl, xl, lg, 그 이하일 경우 디자인을 적용을 했습니다.

추가로 메인 페이지 디자인 변경점입니다.
- 인기차트를 제외한 모든 컴포넌트 박스 제거
- 무한스크롤로 앨범 슬라이드 애니메이션 추가

그리고 util 폴더에 matchMedia라는 파일(함수)를 만들어 두었습니다. 그 함수를 import 해서 사용하면 사용자의 화면 크기에 따라 값을 sm, md, lg, xl, 2xl 값을 반환해 줍니다. 반응형&적응형 디자인을 적용할 때 값을 동적으로 바꿔야할때 사용하면 유용할겁니다.
src/app/main/Chart.tsx에서 matchMedia() 함수를 사용중이니 사용방법이 궁금하면 참고하면 될 것 같습니다.
그리고 matchMedia 함수를 사용하는 컴포넌트를 서버컴포넌트에서 사용할 경우 동적 import가 필요할 수 있습니다.

그리고 네비게이션바 변경사항입니다. 
기존 네비게이션 바는 children 컴포넌트들 위에 네비게이션바를 포지션을 fixed로 사용해서 **'올려놓는'** 방식이었습니다. 그렇기 때문에 항상 children 컴포넌트에서는 padding left값이나 margin left값을 줘야 했고 만약 children 컴포넌트가 넘치면 네비게이션바에 화면이 가려지는 문제가 존재했습니다. (예를들면 화면 사이즈를 줄일때 메인페이지에서 메인페이지 컴포넌트들이 네비바에 묻힘) 그래서 이번에 네비게이션바가 children 컴포넌트가 **'나란히'** 존재하는 방식으로 변경이 되었습니다. 페이지에 있는 컴포넌트와 네비바가 이제 겹치지 않게 되었다는겁니다. 때문에 기존에 설정했던 padding left 또는 margin left 값을 없애줘야 합니다. 최대한 그 설정된 값을 없애봤는데 제가 실수로 미쳐 지우지 못한걸 발견한다면 직접 지워주셔서 설정해주시면 감사하겠습니다. 그리고 네비게이션 바 반응형 디자인 조금 수정되었습니다.

---

### Issue Number
62