### PR TITLE
[fix] 음악 재생 버그수정

### DIFF
--- a/src/api/music.ts
+++ b/src/api/music.ts
@@ -4,7 +4,7 @@
 import axios from 'axios';
 import { getCookie } from '@/app/Cookies';
 
-export const getMusic = async (trackId: number, setIsLiked: any) => {
+export const getMusic = async (trackId: number | null) => {
   try {
     const accessToken = await getCookie('accessToken');
     const response = await axios.get(
@@ -16,7 +16,6 @@ export const getMusic = async (trackId: number, setIsLiked: any) => {
         },
       },
     );
-    setIsLiked(response.data.likes_flag);
     return response.data;
   } catch (error) {
     console.error('오류 발생:', error);

--- a/src/app/components/audio/Audio.tsx
+++ b/src/app/components/audio/Audio.tsx
@@ -23,6 +23,8 @@ interface SharedAudioState {
   setCurrentTime: React.Dispatch<React.SetStateAction<number>>;
   volume: number;
   setVolume: React.Dispatch<React.SetStateAction<number>>;
+  trackId: number | null;
+  setTrackId: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
 const SharedAudioContext = createContext<SharedAudioState | undefined>(
@@ -36,6 +38,7 @@ export const SharedAudioProvider: React.FC<{ children: ReactNode }> = ({
   const [currentTime, setCurrentTime] = useState<number>(0); // 초기 값은 0으로 설정
   // 볼륨조절
   const [volume, setVolume] = useState<number>(30);
+  const [trackId, setTrackId] = useState<number | null>(null);
 
   // 재생 함수
   const playAudio = () => {
@@ -86,6 +89,8 @@ export const SharedAudioProvider: React.FC<{ children: ReactNode }> = ({
     setCurrentTime,
     volume,
     setVolume,
+    trackId,
+    setTrackId,
   };
 
   return (

--- a/src/app/components/audio/Audio.tsx
+++ b/src/app/components/audio/Audio.tsx
@@ -44,14 +44,9 @@ export const SharedAudioProvider: React.FC<{ children: ReactNode }> = ({
   const playAudio = () => {
     if (audioRef.current) {
       audioRef.current.currentTime = currentTime; // 시작 시간 설정
-      audioRef.current
-        .play()
-        .then(() => {
-          console.log('Audio is playing');
-        })
-        .catch((error) => {
-          console.error('Error playing audio:', error);
-        });
+      audioRef.current.play().catch((error) => {
+        console.error('Error playing audio:', error);
+      });
     }
   };
 

--- a/src/app/components/audio/Audio.tsx
+++ b/src/app/components/audio/Audio.tsx
@@ -62,7 +62,7 @@ export const SharedAudioProvider: React.FC<{ children: ReactNode }> = ({
   // 시간 업데이트 핸들러
   const handleTimeUpdate = () => {
     if (audioRef.current) {
-      setCurrentTime(currentTime);
+      setCurrentTime(audioRef.current.currentTime);
     }
   };
 
@@ -75,7 +75,7 @@ export const SharedAudioProvider: React.FC<{ children: ReactNode }> = ({
         audioElement.removeEventListener('timeupdate', handleTimeUpdate);
       };
     }
-  }, [audioRef, handleTimeUpdate]);
+  }, [audioRef]);
 
   // 오디오 상태 및 제어 함수 공유
   const sharedState: SharedAudioState = {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,6 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const trackId = 123;
   return (
     <html lang="ko">
       <head>
@@ -43,7 +42,7 @@ export default function RootLayout({
         <QueryProviders>
           <SharedAudioProvider>
             {children}
-            <MusicBar trackId={trackId} />
+            <MusicBar />
           </SharedAudioProvider>
           <NavigationBar />
         </QueryProviders>

--- a/src/app/track/[trackId]/page.tsx
+++ b/src/app/track/[trackId]/page.tsx
@@ -121,7 +121,7 @@ export default function MusicPage(props: any) {
         audioElement.removeEventListener('timeupdate', handleTimeUpdate);
       };
     }
-  }, [audioRef, isDragging, setCurrentTime]);
+  }, [audioRef, isDragging]);
 
   // 슬라이더 변경 시 음악의 재생 시간을 변경합니다.
   const handleSliderChange = (event: Event, newValue: number | number[]) => {
@@ -139,7 +139,6 @@ export default function MusicPage(props: any) {
   };
 
   useEffect(() => {
-    console.log('hasNextPage : ', hasNextPage, 'fetchNextPage : ', hasNextPage);
     if (!hasNextPage) return;
     const observer = new IntersectionObserver(
       (entries) => {

--- a/src/app/track/[trackId]/page.tsx
+++ b/src/app/track/[trackId]/page.tsx
@@ -290,7 +290,6 @@ export default function MusicPage(props: any) {
                     onClick={() => {
                       playAudio();
                       setIsPaused(false);
-                      console.log('trackId:', trackId);
                     }}
                     disabled={musicLoading}
                   >

--- a/src/app/track/[trackId]/page.tsx
+++ b/src/app/track/[trackId]/page.tsx
@@ -258,32 +258,28 @@ export default function MusicPage(props: any) {
               </div>
               <div className="flex justify-between">
                 {isLiked ? (
-                  <IconButton>
-                    <Favorite
-                      color="secondary"
-                      fontSize="large"
-                      onClick={() => {
-                        setIsLiked(false);
-                        disLikes(props.params.trackId).catch(() => {
-                          // API 호출이 실패하면 상태를 되돌립니다
-                          setIsLiked(true);
-                        });
-                      }}
-                    />
+                  <IconButton
+                    onClick={() => {
+                      setIsLiked(false);
+                      disLikes(props.params.trackId).catch(() => {
+                        // API 호출이 실패하면 상태를 되돌립니다
+                        setIsLiked(true);
+                      });
+                    }}
+                  >
+                    <Favorite color="secondary" fontSize="large" />
                   </IconButton>
                 ) : (
-                  <IconButton>
-                    <FavoriteBorder
-                      color="secondary"
-                      fontSize="large"
-                      onClick={() => {
-                        setIsLiked(true);
-                        likes(props.params.trackId).catch(() => {
-                          // API 호출이 실패하면 상태를 되돌립니다
-                          setIsLiked(false);
-                        });
-                      }}
-                    />
+                  <IconButton
+                    onClick={() => {
+                      setIsLiked(true);
+                      likes(props.params.trackId).catch(() => {
+                        // API 호출이 실패하면 상태를 되돌립니다
+                        setIsLiked(false);
+                      });
+                    }}
+                  >
+                    <FavoriteBorder color="secondary" fontSize="large" />
                   </IconButton>
                 )}
                 <IconButton>
@@ -358,16 +354,6 @@ export default function MusicPage(props: any) {
               <h1 className="m-0 h-fit text-4xl text-white drop-shadow-lg">
                 Playlist
               </h1>
-              {/* <Button
-                color="secondary"
-                id="basic-button"
-                aria-controls={open ? 'basic-menu' : undefined}
-                aria-haspopup="true"
-                aria-expanded={open ? 'true' : undefined}
-                onClick={handleClick}
-              >
-                재생목록 선택
-              </Button> */}
               <Menu
                 id="basic-menu"
                 anchorEl={anchorEl}
@@ -376,21 +362,7 @@ export default function MusicPage(props: any) {
                 MenuListProps={{
                   'aria-labelledby': 'basic-button',
                 }}
-              >
-                {/* {listLoading
-                  ? 'loading'
-                  : listData.content.map((e: any) => (
-                      <MenuItem
-                        key={e.track_id}
-                        onClick={() => {
-                          handleClose();
-                          // setSelectedPlaylist(e.playlist_id);
-                        }}
-                      >
-                        {e.title}
-                      </MenuItem>
-                    ))} */}
-              </Menu>
+              ></Menu>
             </div>
             <Divider
               variant="fullWidth"

--- a/src/app/track/[trackId]/page.tsx
+++ b/src/app/track/[trackId]/page.tsx
@@ -373,7 +373,7 @@ export default function MusicPage(props: any) {
               {data.pages.map((page: any) =>
                 page.content.map((content: any) => (
                   <li
-                    key={content.id}
+                    key={content.track_id}
                     className="flex w-full flex-row space-x-4 self-start p-2 hover:rounded-md hover:bg-[#040404] hover:bg-opacity-30"
                   >
                     <img


### PR DESCRIPTION
### PR Type

<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [x] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

---

### Summary
* 음악 재생 시 슬라이더가 업데이트 되지 않는 버그 수정
* 음악상세페이지 및 뮤직바에서 재생 슬라이더를 드래그하여 슬라이더 바깥에서 mouseup하고 난 후 슬라이더가 더이상 움직이지 않던 버그 수정
* 처음 음악페이지에 접근하였을 때 음악재생이 되지 않던 버그 수정
* musicbar 컴포넌트 layout에서 props 선언 방식이 정적으로 되어있어서 수정
* 음악상세페이지에 재생목록 데이터 받아올때 key값을 없는 값인 content.id 로 설정되어있어서 실제 존재하는 값인 content.track_id 로 수정
---

### Description

---

### Issue Number
