### PR TITLE
[design] 플레이리스트 페이지 적응형 디자인 적용

### DIFF
--- a/src/app/auth/[loginType]/page.tsx
+++ b/src/app/auth/[loginType]/page.tsx
@@ -28,7 +28,7 @@ function page(props: any) {
     }
     router.push('/main');
   }, [accessToken, refreshToken]);
-  return <div>잘못된 접근입니다.</div>;
+  return <div></div>;
 }
 
 export default page;

--- a/src/app/components/AlbumCover/AlbumCoverSystem.tsx
+++ b/src/app/components/AlbumCover/AlbumCoverSystem.tsx
@@ -30,7 +30,7 @@ function AlbumCoverSystem({ image, title, id, type }: albumCoverSystemProps) {
   return (
     <>
       <Link
-        href={`/playlist/type=${type}&i=${id}`}
+        href={`/playlist/type=${type}&id=${id}`}
         className="hover-bg-opacity flex h-36 cursor-pointer flex-col items-center justify-center px-4 xl:h-40 2xl:h-44"
       >
         <figure

--- a/src/app/components/AlbumCover/AlbumCoverUser.tsx
+++ b/src/app/components/AlbumCover/AlbumCoverUser.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable operator-linebreak */
-/* eslint-disable import/no-unresolved */
-/* eslint-disable no-unused-vars */
-/* eslint-disable @next/next/no-img-element */
+
 import { albumCoverUserProps } from '@/types/albumCover.ts';
 import Link from 'next/link';
 import Image from 'next/image';
@@ -18,36 +16,38 @@ function AlbumCoverUser({
   return (
     <Link
       href={href}
-      className="hover-bg-opacity flex h-60 w-60 cursor-pointer flex-col items-center justify-center p-4 pt-10 xl:h-64 2xl:h-80"
+      className="hover-bg-opacity flex h-60 w-40 cursor-pointer flex-col items-center justify-start p-4 pt-10 xl:h-64 xl:w-48 xl:pt-10 2xl:h-72 2xl:w-48 2xl:pt-10"
     >
-      <figure className="relative z-30 h-32 w-32 rounded-lg xl:h-36 xl:w-36 2xl:h-40 2xl:w-40">
-        <Image
-          src={image1}
-          alt="Album cover"
-          className="z-30 rounded-lg"
-          fill
-          sizes="100vm"
-        />
-      </figure>
-      <figure className="relative z-20 -mt-32 h-28 w-28 rounded-lg xl:-mt-36 xl:h-32 xl:w-32 2xl:-mt-44 2xl:h-36 2xl:w-36">
-        <Image
-          src={image2}
-          alt="Album cover"
-          className="z-20 rounded-lg"
-          fill
-          sizes="100vm"
-        />
-      </figure>
-      <figure className="relative z-10 -mt-28 h-24 w-24 rounded-lg xl:-mt-32 xl:h-28 xl:w-28 2xl:-mt-40 2xl:h-32 2xl:w-32">
-        <Image
-          src={image3}
-          alt="Album cover"
-          className="z-10 rounded-lg"
-          fill
-          sizes="100vm"
-        />
-      </figure>
-      <p className="text-md mt-16 h-16 text-center font-bold text-white xl:mt-20 xl:text-lg">
+      <div className="flex flex-col items-center justify-start">
+        <figure className="relative z-30 h-32 w-32 rounded-lg xl:h-36 xl:w-36 2xl:h-40 2xl:w-40">
+          <Image
+            src={image1}
+            alt="Album cover"
+            className="z-30 rounded-lg"
+            fill
+            sizes="100vm"
+          />
+        </figure>
+        <figure className="relative z-20 -mt-[8.75rem] h-28 w-28 rounded-lg xl:-mt-[9.75rem] xl:h-32 xl:w-32 2xl:-mt-44 2xl:h-36 2xl:w-36">
+          <Image
+            src={image2}
+            alt="Album cover"
+            className="z-20 rounded-lg"
+            fill
+            sizes="100vm"
+          />
+        </figure>
+        <figure className="relative z-10 -mt-[7.75rem] h-24 w-24 rounded-lg xl:-mt-[8.75rem] xl:h-28 xl:w-28 2xl:-mt-40 2xl:h-32 2xl:w-32">
+          <Image
+            src={image3}
+            alt="Album cover"
+            className="z-10 rounded-lg"
+            fill
+            sizes="100vm"
+          />
+        </figure>
+      </div>
+      <p className="text-md mt-16 h-16 text-center font-bold text-white xl:mt-16 xl:text-lg 2xl:mt-20 2xl:text-lg">
         {title}
       </p>
     </Link>

--- a/src/app/main/AllPlayList.tsx
+++ b/src/app/main/AllPlayList.tsx
@@ -105,7 +105,7 @@ function AllPlayListComponent() {
                   : content.tracks[2].thumbnail_image
               }
               title={content.playlist_name}
-              Id={content.playlist_id}
+              id={content.playlist_id}
             />
           )),
         )}

--- a/src/app/main/SystemPlaylist.tsx
+++ b/src/app/main/SystemPlaylist.tsx
@@ -92,8 +92,8 @@ function SystemPlaylist() {
               key={pageIndex * 6 + index}
               image={playlist.tracks[0].thumbnail_image}
               title={playlist.playlist_name}
-              Id={playlist.playlist_id}
-              curation="SystemPlaylist"
+              id={playlist.playlist_id}
+              type="curated"
             />
           )),
         )}

--- a/src/app/main/Tag.tsx
+++ b/src/app/main/Tag.tsx
@@ -92,8 +92,8 @@ function Tag() {
               key={pageIndex * 6 + index}
               image={tag.tag_image}
               title={tag.tag_name}
-              Id={tag.tag_id}
-              curation="tag"
+              id={tag.tag_id}
+              type="tag"
             />
           )),
         )}

--- a/src/app/playlist/FollowPlaylist.tsx
+++ b/src/app/playlist/FollowPlaylist.tsx
@@ -1,30 +1,32 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react-hooks/rules-of-hooks */
 
 'use client';
 
 import { ThemeProvider } from '@emotion/react';
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { IconButton } from '@mui/material';
 import BackIcon from '@mui/icons-material/ArrowBackIosNew';
 import ForwardIcon from '@mui/icons-material/ArrowForwardIos';
 import { useQuery } from '@tanstack/react-query';
 import { getSlideContentStyle } from '@/app/styles/slide.ts';
 import { fetchFollowPlaylistData } from '@/api/playlist.ts';
-import Link from 'next/link';
 import theme from '../styles/theme.ts';
 import AlbumCoverUser from '../components/AlbumCover/AlbumCoverUser.tsx';
 
-function followPlaylistComponent() {
+function FollowPlaylist() {
   const [pageIndex, setPageIndex] = useState<number>(0);
   const musicList = [];
+  const divRef = useRef(null);
+  const [isVisible, setIsVisible] = useState(true);
 
   const { isLoading, data } = useQuery({
-    queryKey: ['followPlaylistThumbnail'],
+    queryKey: ['FollowPlaylistThumbnail'],
     queryFn: fetchFollowPlaylistData,
   });
 
   const handleForwardClick = () => {
-    if (data.content.length - 6 > pageIndex) {
+    if (isVisible) {
       setPageIndex(pageIndex + 1);
     }
   };
@@ -34,6 +36,33 @@ function followPlaylistComponent() {
       setPageIndex(pageIndex - 1);
     }
   };
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(false);
+          } else {
+            setIsVisible(true);
+          }
+        });
+      },
+      {
+        threshold: 0.5, // 10% 가시성을 기준으로 설정
+      },
+    );
+
+    if (divRef.current) {
+      observer.observe(divRef.current);
+    }
+
+    return () => {
+      if (divRef.current) {
+        observer.unobserve(divRef.current);
+      }
+    };
+  }, [divRef.current]);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -45,38 +74,36 @@ function followPlaylistComponent() {
       if (data.content[i]) {
         // 데이터가 존재하는 경우에만 생성
         musicList.push(
-          <Link
-            href={`/playlist/${data.content[i].playlist_Id}`} // 플레이리스트 이름으로 링크, 그러나 아이디로 링크할 수도 있음(수정 가능성 있음)
-            className="flex w-1/6 items-center justify-center"
-          >
+          <div key={i}>
             <AlbumCoverUser
               image1={data.content[i].thumbnails[0]}
               image2={data.content[i].thumbnails[1]}
               image3={data.content[i].thumbnails[2]}
               title={data.content[i].playlist_name}
-              Id={data.content[i].playlist_id}
+              id={data.content[i].playlist_id}
             />
-          </Link>,
+          </div>,
         );
       }
     }
   }
   return (
     <ThemeProvider theme={theme}>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center rounded-2xl opacity-95">
+      <div className="bg-zinc-650 z-30 flex h-full w-10 items-center justify-center first-letter:flex-row">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
       </div>
       <div
         className={
-          'slide-content flex h-full w-5/6 flex-col flex-wrap items-start justify-center'
+          'slide-content flex h-full w-full flex-col flex-wrap items-start justify-center'
         }
-        style={getSlideContentStyle(pageIndex, 6)}
+        style={getSlideContentStyle(pageIndex, 3)}
       >
         {musicList}
+        <div ref={divRef} />
       </div>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center rounded-2xl opacity-95">
+      <div className="bg-zinc-650 z-30 flex h-full w-10 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>
@@ -85,4 +112,4 @@ function followPlaylistComponent() {
   );
 }
 
-export default followPlaylistComponent;
+export default FollowPlaylist;

--- a/src/app/playlist/FollowSystemPlaylist.tsx
+++ b/src/app/playlist/FollowSystemPlaylist.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable no-unused-vars */
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react-hooks/rules-of-hooks */
 
 'use client';
 
 import { ThemeProvider } from '@emotion/react';
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { IconButton } from '@mui/material';
 import BackIcon from '@mui/icons-material/ArrowBackIosNew';
 import ForwardIcon from '@mui/icons-material/ArrowForwardIos';
@@ -12,10 +12,39 @@ import theme from '../styles/theme.ts';
 
 function systemPlaylistComponent() {
   const [pageIndex, setPageIndex] = useState<number>(0);
-  const [data] = useState<any>([]);
+  // const [data] = useState<any>([]);
+  const divRef = useRef(null);
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(false);
+          } else {
+            setIsVisible(true);
+          }
+        });
+      },
+      {
+        threshold: 0.1, // 10% 가시성을 기준으로 설정
+      },
+    );
+
+    if (divRef.current) {
+      observer.observe(divRef.current);
+    }
+
+    return () => {
+      if (divRef.current) {
+        observer.unobserve(divRef.current);
+      }
+    };
+  }, [divRef.current]);
 
   const handleForwardClick = () => {
-    if (data.length - 4 > pageIndex) {
+    if (isVisible) {
       setPageIndex(pageIndex + 1);
     }
   };
@@ -26,18 +55,17 @@ function systemPlaylistComponent() {
     }
   };
 
-  // if (isLoading) {
-  //   return <div>Loading...</div>;
-  // }
   return (
     <ThemeProvider theme={theme}>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center rounded-2xl opacity-95">
+      <div className="bg-zinc-650 z-30 flex h-full w-10 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
       </div>
-      <div className="flex h-full w-10/12 flex-row items-center justify-start rounded-2xl"></div>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center rounded-2xl opacity-95">
+      <div className="flex h-full w-10/12 flex-row items-center justify-start rounded-2xl">
+        <div ref={divRef} />
+      </div>
+      <div className="bg-zinc-650 z-30 flex h-full w-10 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/playlist/MyPlaylist.tsx
+++ b/src/app/playlist/MyPlaylist.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ThemeProvider } from '@emotion/react';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { IconButton } from '@mui/material';
 import BackIcon from '@mui/icons-material/ArrowBackIosNew';
 import ForwardIcon from '@mui/icons-material/ArrowForwardIos';
@@ -23,8 +23,10 @@ import AlbumCoverUser from '../components/AlbumCover/AlbumCoverUser.tsx';
 function MyPlaylistComponent() {
   const [pageIndex, setPageIndex] = useState(0);
   const [publicScope, setPublicScope] = useState(false);
+  const [isVisible, setIsVisible] = useState(true);
   const [createPlayListModalOpen, setCreatePlayListModalOpen] = useState(false);
   const musicList = [];
+  const divRef = useRef(null);
 
   const { isLoading, data: myPlaylistData } = useQuery({
     queryKey: ['myPlaylistThumbnail'],
@@ -36,8 +38,35 @@ function MyPlaylistComponent() {
     queryFn: fetchLikePlaylistThumbnail,
   });
 
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(false);
+          } else {
+            setIsVisible(true);
+          }
+        });
+      },
+      {
+        threshold: 0.1, // 10% 가시성을 기준으로 설정
+      },
+    );
+
+    if (divRef.current) {
+      observer.observe(divRef.current);
+    }
+
+    return () => {
+      if (divRef.current) {
+        observer.unobserve(divRef.current);
+      }
+    };
+  }, [divRef.current]);
+
   const handleForwardClick = () => {
-    if (myPlaylistData.content.length - 4 > pageIndex) {
+    if (isVisible) {
       setPageIndex(pageIndex + 1);
     }
   };
@@ -54,7 +83,7 @@ function MyPlaylistComponent() {
       if (myPlaylistData.content[i]) {
         // 데이터가 존재하는 경우에만 생성
         musicList.push(
-          <>
+          <div key={i}>
             <AlbumCoverUser
               image1={myPlaylistData.content[i].thumbnails[0]}
               image2={myPlaylistData.content[i].thumbnails[1]}
@@ -62,7 +91,7 @@ function MyPlaylistComponent() {
               title={myPlaylistData.content[i].playlist_name}
               id={myPlaylistData.content[i].playlist_id}
             />
-          </>,
+          </div>,
         );
       }
     }
@@ -172,7 +201,7 @@ function MyPlaylistComponent() {
       {/* 모달창 */}
       {createPlayListModalOpen && NewPlaylistModal}
 
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center rounded-2xl opacity-95">
+      <div className="bg-zinc-650 z-30 flex h-full w-10 flex-row items-center justify-center">
         <IconButton onClick={handleBackwardClick}>
           {pageIndex !== 0 && <BackIcon color="primary" fontSize="large" />}
         </IconButton>
@@ -180,19 +209,19 @@ function MyPlaylistComponent() {
 
       <div
         className={
-          'slide-content flex h-full w-5/6 flex-col flex-wrap items-start justify-center'
+          'slide-content flex h-full w-full flex-col flex-wrap items-start justify-center'
         }
-        style={getSlideContentStyle(pageIndex, 6)}
+        style={getSlideContentStyle(pageIndex, 3)}
       >
         {/* 플리 생성 버튼 */}
         <div
-          className="hover-bg-big m-4 mt-12 flex h-auto w-56 cursor-pointer flex-col items-center justify-center"
+          className="hover-bg-big -mx-8 mt-12 flex w-56 cursor-pointer flex-col items-center justify-center xl:-mx-4 2xl:mt-8"
           onClick={() => setCreatePlayListModalOpen(true)}
         >
-          <div className="flex h-48 w-48 items-center justify-center rounded-lg bg-zinc-500">
+          <div className="z-30 flex h-32 w-32 items-center justify-center rounded-lg bg-zinc-500 xl:h-36 xl:w-36 2xl:h-40 2xl:w-40">
             <AddIcon color="primary" fontSize="large" />
           </div>
-          <p className="mt-4 text-center text-lg text-white">
+          <p className="text-md mt-4 h-16 text-center font-bold text-white xl:text-lg">
             플레이리스트 생성
           </p>
         </div>
@@ -208,8 +237,9 @@ function MyPlaylistComponent() {
 
         {/* 내가 생성한 플리 버튼 */}
         {musicList}
+        <div ref={divRef} />
       </div>
-      <div className="bg-gray-650 z-30 flex h-full w-1/12 flex-row items-center justify-center rounded-2xl opacity-95">
+      <div className="bg-zinc-650 z-30 flex h-full w-10 flex-row items-center justify-center">
         <IconButton onClick={handleForwardClick}>
           <ForwardIcon color="primary" fontSize="large" />
         </IconButton>

--- a/src/app/playlist/MyPlaylist.tsx
+++ b/src/app/playlist/MyPlaylist.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+
 'use client';
 
 import { ThemeProvider } from '@emotion/react';
@@ -149,43 +151,51 @@ function MyPlaylistComponent() {
           setCreatePlayListModalOpen(false);
         }}
       />
-      <div className="z-50 flex h-3/5 w-3/5 flex-col rounded-2xl border-4 border-gray-400 bg-zinc-800 p-8 drop-shadow-md">
-        <h1 className="mt-16 text-4xl text-white">새로운 플레이리스트</h1>
-        <input
-          className="my-24 h-12 w-3/4 border-b border-gray-500 bg-zinc-800 p-4 text-xl text-gray-100 focus:outline-none"
-          placeholder="플레이리스트 이름을 입력하세요"
-        />
-        <p className="my-6 text-sm text-zinc-600">공개 범위</p>
-        <div
-          className="flex w-1/5 cursor-pointer flex-row items-center border-b border-gray-500 px-4 text-xl"
-          style={{ userSelect: 'none' }}
-          onClick={() => setPublicScope(!publicScope)}
-        >
-          <div className="w-full">{publicScope ? 'Public' : 'Private'}</div>
-          <IconButton>
-            {publicScope ? (
-              <LockOpenIcon color="primary" fontSize="large" />
-            ) : (
-              <LockIcon color="primary" fontSize="large" />
-            )}
-          </IconButton>
-        </div>
-        {publicScope && (
-          <div className="my-6 text-sm text-zinc-600">
-            ! 공개 범위를 Public으로 설정하면 모든 사람들이 회원님의
-            플레이리스트를 볼 수 있습니다.
+      <div className="z-50 flex h-3/5 w-4/5 min-w-96 flex-col rounded-2xl border-4 border-gray-400 bg-zinc-800 p-8 drop-shadow-md xl:w-2/3 2xl:w-3/5">
+        <h1 className="flex h-1/6 items-center justify-start text-xl text-white xl:text-2xl 2xl:text-3xl">
+          새로운 플레이리스트
+        </h1>
+        <div className="flex h-4/6 flex-col items-start justify-around">
+          <input
+            className="my-6 h-12 w-3/4 border-b border-gray-500 bg-zinc-800 p-4 text-base text-gray-100 focus:outline-none 2xl:text-lg"
+            placeholder="플레이리스트 이름을 입력하세요"
+          />
+          <div className="flex w-full flex-col">
+            <p className="my-3 text-sm text-zinc-600">공개 범위</p>
+            <div className="flex w-full flex-row">
+              <div
+                className="flex min-w-20 cursor-pointer flex-row items-center border-b border-gray-500 px-4 text-base 2xl:text-lg"
+                style={{ userSelect: 'none' }}
+                onClick={() => setPublicScope(!publicScope)}
+              >
+                <p className="w-full">{publicScope ? 'Public' : 'Private'}</p>
+                <IconButton>
+                  {publicScope ? (
+                    <LockOpenIcon color="primary" fontSize="large" />
+                  ) : (
+                    <LockIcon color="primary" fontSize="large" />
+                  )}
+                </IconButton>
+              </div>
+              {publicScope && (
+                <div className="my-2 flex h-full items-center justify-center text-sm text-zinc-600">
+                  ! 공개 범위를 Public으로 설정하면 모든 사람들이 회원님의
+                  플레이리스트를 볼 수 있습니다.
+                </div>
+              )}
+            </div>
           </div>
-        )}
-        <div className="flex h-full w-full flex-row items-end justify-end">
+        </div>
+        <div className="flex h-1/6 w-full flex-row items-end justify-end">
           <p
-            className="hover-bg-opacity m-4 flex h-16 w-32  cursor-pointer items-center justify-center text-xl font-bold text-white hover:rounded-full"
+            className="hover-bg-opacity mx-4 flex w-32 cursor-pointer items-center justify-center p-4 font-bold text-white *:text-base hover:rounded-full xl:text-xl"
             onClick={() => handleCancelClick()}
           >
             취소
           </p>
 
           <p
-            className="hover-bg-opacity m-4 flex h-16 w-32 cursor-pointer items-center justify-center rounded-full bg-white text-xl font-bold text-purple-700 hover:rounded-full"
+            className="hover-bg-opacity mx-4 flex w-32 cursor-pointer items-center justify-center rounded-full bg-white p-4 text-base font-bold text-purple-700 hover:rounded-full xl:text-xl"
             onClick={() => handleAddPlaylist()}
           >
             확인
@@ -221,7 +231,7 @@ function MyPlaylistComponent() {
           <div className="z-30 flex h-32 w-32 items-center justify-center rounded-lg bg-zinc-500 xl:h-36 xl:w-36 2xl:h-40 2xl:w-40">
             <AddIcon color="primary" fontSize="large" />
           </div>
-          <p className="text-md mt-4 h-16 text-center font-bold text-white xl:text-lg">
+          <p className="mt-4 h-16 text-center text-base font-bold text-white xl:text-lg">
             플레이리스트 생성
           </p>
         </div>

--- a/src/app/playlist/[param]/MusicElement.tsx
+++ b/src/app/playlist/[param]/MusicElement.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link';
 import CancelIcon from '@mui/icons-material/Cancel';
 import Swal from 'sweetalert2';
 import { deleteTrack } from '@/api/playlist.ts';
+import Image from 'next/image';
 import theme from '../../styles/theme.ts';
 
 export default function MusicElement({
@@ -128,20 +129,24 @@ export default function MusicElement({
             href={`/track/${trackId}`}
             className={`flex w-full flex-row items-center ${isEdit ? 'transform-playlist-edit' : 'transform-playlist-normal'}`}
           >
-            <img
-              src={image}
-              alt="Album cover"
-              className="h-24 w-24 rounded-lg"
-            />
-            <p className="mx-6 flex text-2xl">{title}</p>
+            <figure className="relative h-16 w-16 rounded-lg">
+              <Image
+                src={image}
+                alt="Album cover"
+                className="rounded-lg"
+                fill
+                sizes="100vw"
+              />
+            </figure>
+            <p className="mx-6 flex text-base">{title}</p>
           </Link>
 
-          <div className="flex w-2/12 items-center justify-center text-2xl">
+          <div className="mr-2 flex w-2/12 items-center justify-center text-base">
             <IconButton onClick={handleLike}>
               {isLikedStore ? (
-                <FavoriteIcon color="primary" fontSize="inherit" />
+                <FavoriteIcon color="primary" fontSize="small" />
               ) : (
-                <FavoriteBorderIcon color="primary" />
+                <FavoriteBorderIcon color="primary" fontSize="small" />
               )}
             </IconButton>
 
@@ -149,7 +154,7 @@ export default function MusicElement({
           </div>
           <div className="flex w-24 items-center justify-center">
             <IconButton>
-              <PlayArrowIcon color="primary" fontSize="large" />
+              <PlayArrowIcon color="primary" fontSize="inherit" />
             </IconButton>
           </div>
         </div>

--- a/src/app/playlist/[param]/PlayButton.tsx
+++ b/src/app/playlist/[param]/PlayButton.tsx
@@ -10,7 +10,7 @@ function PlayButton(playlistId: any) {
   return (
     <ThemeProvider theme={theme}>
       <IconButton className="mx-8">
-        <PlayCircleIcon color="primary" style={{ fontSize: 60, opacity: 1 }} />
+        <PlayCircleIcon color="primary" style={{ fontSize: 40, opacity: 1 }} />
       </IconButton>
     </ThemeProvider>
   );

--- a/src/app/playlist/[param]/page.tsx
+++ b/src/app/playlist/[param]/page.tsx
@@ -137,7 +137,7 @@ function page(props: any) {
   return (
     <div className="-z-10 flex h-full w-full flex-col items-end justify-center overflow-hidden">
       {playlistType === 'genre' && (
-        <div className="relative -z-10 -mb-20 flex h-40 w-full items-center justify-center">
+        <div className="relative -z-10 -mb-20 flex h-64 w-full items-center justify-center">
           <Image
             src={data.pages['0'].genre_image}
             alt="playlist"
@@ -149,7 +149,7 @@ function page(props: any) {
             className="bg-gray-650 absolute bottom-0 left-0 flex h-full w-full items-end justify-end p-4 text-white"
             style={{
               background:
-                'linear-gradient(to top, rgba(26, 26, 26, 1) 10%,rgba(26, 26, 26, 0.95) 30%,  rgba(26, 26, 26, 0.1) 100%)',
+                'linear-gradient(to top, rgba(26, 26, 26, 1) 10%,rgba(26, 26, 26, 0.9) 30%,  rgba(26, 26, 26, 0) 100%)',
             }}
           />
         </div>
@@ -162,13 +162,13 @@ function page(props: any) {
               <div className="flex flex-row items-center justify-start">
                 <input
                   type="text"
-                  className="bg-gray-650 h-16 w-auto rounded-2xl p-4 text-4xl text-white focus:outline-none"
+                  className="bg-gray-650 h-16 w-auto rounded-2xl p-4 text-xl text-white focus:outline-none xl:text-2xl 2xl:text-3xl"
                   value={playlistName}
                   onChange={(e) => setPlaylistName(e.target.value)}
                 />
                 <button
                   type="button"
-                  className="mx-2 flex h-14 w-28 items-center justify-center rounded-2xl bg-zinc-700 p-2 text-2xl text-white focus:outline-none"
+                  className="mx-2 flex h-14 w-28 items-center justify-center rounded-2xl bg-zinc-700 p-2 text-lg text-white focus:outline-none xl:text-xl 2xl:text-2xl"
                   onClick={() => {
                     setEditOpen(false);
                     patchPlaylistName(playlistId, playlistName);
@@ -256,13 +256,13 @@ function page(props: any) {
           )}
         </div>
         {/* 플리 박스 */}
-        <div className="bg-gray-650 flex h-auto w-full flex-col items-center rounded-2xl p-8">
+        <div className="bg-gray-650 flex h-auto w-full min-w-[42rem] flex-col items-center rounded-2xl p-8">
           <div className="flex w-full flex-row">
-            <p className="flex w-full px-20 text-2xl"> 곡 정보</p>
-            <p className="flex w-2/12 items-center justify-center text-2xl">
+            <p className="flex w-full px-20 text-lg"> 곡 정보</p>
+            <p className="flex w-2/12 items-center justify-center text-lg">
               좋아요
             </p>
-            <p className="flex w-24 justify-center text-2xl ">재생</p>
+            <p className="flex w-24 justify-center text-lg ">재생</p>
           </div>
           <hr className="my-6 w-full border-zinc-600" />
           {/* 음악 요소들 */}
@@ -286,6 +286,7 @@ function page(props: any) {
           />
         </div>
       </div>
+      <div className="flex h-20 w-full items-center justify-center" />
     </div>
   );
 }

--- a/src/app/playlist/page.tsx
+++ b/src/app/playlist/page.tsx
@@ -9,27 +9,26 @@ async function page() {
     <>
       <div className="flex h-full w-full flex-col items-start justify-start overflow-hidden px-6">
         {/* 내가 생성한 플레이리스트 */}
-        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
+        <h1 className="mb-4 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           내가 생성한 플레이리스트
         </h1>
-        <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
+        <div className="flex h-64 w-full flex-row items-center justify-center overflow-hidden xl:h-72 2xl:h-80">
           <MyPlaylistComponent />
         </div>
 
         {/* 팔로우한 플레이리스트 */}
-        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
-          {' '}
-          플레이리스트
+        <h1 className="mb-4 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
+          팔로우한 플레이리스트
         </h1>
-        <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center overflow-hidden rounded-2xl">
+        <div className="flex h-64 w-full flex-row items-center justify-center overflow-hidden xl:h-72 2xl:h-80">
           <FollowPlaylistComponent />
         </div>
 
         {/* 시스템 플레이리스트 */}
-        <h1 className="mb-5 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
+        <h1 className="mb-4 mt-14 text-xl font-bold xl:text-2xl 2xl:text-3xl">
           구독한 플레이리스트
         </h1>
-        <div className="bg-gray-650 flex h-80 w-full flex-row items-center justify-center rounded-2xl">
+        <div className="flex h-64 w-full flex-row items-center justify-center overflow-hidden xl:h-72 2xl:h-80">
           <FollowSystemPlaylist />
         </div>
       </div>


### PR DESCRIPTION
### PR Type

<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [ ] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [x] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

---

### Summary
플레이리스트 페이지 적응형 디자인 적용

---

### Description
플레이리스트 페이지 적응형 디자인 적용했습니다.
앨범 3개 겹쳐있는 디자인인 AlbumCoverUser 공용 컴포넌트의 수정이 많았습니다. 간격 이쁘게 맞추고 margin값도 정리해 두었습니다.
그리고 플레이리스트 페이지의 회색 박스도 메인페이지와 동일하게 제거했습니다.
플레이리스트 상세페이지도 적응형 작업이 들어갔는데 제목 글씨 크기는 동적으로 했지만 음악 제목과 좋아요 수 등등 박스 안에 있는 내용은 고정으로 해 두었습니다. 다른 음악 스트리밍 서비스를 보면 변하지 않더라고요. 그리고 커지면 너무 안이뻐서 그냥 그것만 정적으로 하고 나머지 제목은 동적으로 해 두었습니다.
그리고 장르 플레이리스트에 배경이 왼쪽 오른쪽이 잘리는 문제가 있었는데 화면에 꽉 차도록 수정해두었습니다.
그리고 배포를 위해 build과정 거치고 모든 오류 수정했습니다.

---

### Issue Number
73